### PR TITLE
fix(web): auth middleware not applied globally + login error toast

### DIFF
--- a/apps/web/composables/useApi.ts
+++ b/apps/web/composables/useApi.ts
@@ -61,24 +61,28 @@ function unwrap<T>(response: unknown): T {
 /**
  * Extract a human-readable error message from a caught error.
  * Handles: ApiError, $fetch FetchError (with .data body), generic Error.
+ *
+ * Note: ofetch defines `data` as a getter via Object.defineProperty, so we
+ * must access it directly rather than relying solely on `'data' in err`.
  */
 export function extractApiError(err: unknown): string {
   // ApiError from our unwrap
   if (err instanceof ApiError) {
     return err.firstError
   }
-  // $fetch FetchError — the JSON error body is in err.data
-  if (
-    err !== null &&
-    typeof err === 'object' &&
-    'data' in err
-  ) {
-    const data = (err as { data?: JsonResponse }).data
+  // $fetch FetchError — the JSON error body is in err.data (getter from response._data)
+  if (err !== null && typeof err === 'object') {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const data = (err as any).data as JsonResponse | undefined
     if (data?.message) return data.message
     if (data?.errors) {
       const firstField = Object.values(data.errors)[0]
       if (firstField?.[0]) return firstField[0]
     }
+    // Also check statusMessage from ofetch
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const statusMessage = (err as any).statusMessage as string | undefined
+    if (statusMessage) return statusMessage
   }
   if (err instanceof Error) return err.message
   return 'Something went wrong'

--- a/apps/web/composables/useAuth.ts
+++ b/apps/web/composables/useAuth.ts
@@ -61,5 +61,27 @@ export function useAuth() {
     navigateTo('/login')
   }
 
-  return { token, user, isAuthenticated, login, register, logout }
+  /**
+   * Validate the stored token by calling /auth/me.
+   * If the token is expired or invalid, clear it and return false.
+   * Called by the auth middleware on initial navigation when a cookie exists but user state is empty.
+   */
+  async function fetchUser(): Promise<boolean> {
+    if (!token.value) return false
+    try {
+      const response = await $fetch<{ ret: number; data: AuthUser }>(`${baseURL}/auth/me`, {
+        headers: { Authorization: `Bearer ${token.value}` },
+      })
+      const data = response.data ?? (response as unknown as AuthUser)
+      user.value = data
+      return true
+    } catch {
+      // Token expired or invalid — clear auth state
+      token.value = null
+      user.value = null
+      return false
+    }
+  }
+
+  return { token, user, isAuthenticated, login, register, logout, fetchUser }
 }

--- a/apps/web/middleware/auth.global.ts
+++ b/apps/web/middleware/auth.global.ts
@@ -1,8 +1,13 @@
-export default defineNuxtRouteMiddleware((to, _from) => {
+export default defineNuxtRouteMiddleware(async (to, _from) => {
   const auth = useAuth()
 
   // Guest-only routes where authenticated users should be redirected
   const guestOnlyRoutes = ['/login', '/register']
+
+  // If we have a token cookie but no user loaded yet, validate it
+  if (auth.token.value && !auth.user.value) {
+    await auth.fetchUser()
+  }
 
   // If unauthenticated and trying to access a protected route (not /login or /register)
   if (!auth.isAuthenticated.value && !guestOnlyRoutes.includes(to.path)) {

--- a/apps/web/tests/composables/useAuth.spec.ts
+++ b/apps/web/tests/composables/useAuth.spec.ts
@@ -260,3 +260,69 @@ describe('AC6: isAuthenticated is a computed ref', () => {
     expect(auth.isAuthenticated.value).toBe(false)
   })
 })
+
+// ──────────────────────────────────────────────────────────────────────────────
+// AC7 — fetchUser() validates token and clears on failure
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('AC7: fetchUser validates token', () => {
+  test('source defines a fetchUser function', () => {
+    const source = readFileSync(composablePath, 'utf-8')
+    expect(source).toContain('fetchUser')
+    expect(source).toContain('/auth/me')
+  })
+
+  test('fetchUser returns true and sets user on success', async () => {
+    const env = makeFakeEnv()
+    const { tokenRef, userRef } = env
+
+    tokenRef.value = 'valid-jwt'
+    env.fetchMock.mockResolvedValueOnce({
+      ret: 0,
+      data: { id: '1', email: 'admin@koda.test', name: 'Admin' },
+    })
+
+    applyNuxtGlobals(env)
+
+    const mod = await import(`${composablePath}`)
+    const auth = mod.useAuth()
+
+    const result = await auth.fetchUser()
+
+    expect(result).toBe(true)
+    expect(userRef.value).toMatchObject({ id: '1', email: 'admin@koda.test' })
+  })
+
+  test('fetchUser returns false and clears token on failure', async () => {
+    const env = makeFakeEnv()
+    const { tokenRef, userRef } = env
+
+    tokenRef.value = 'expired-jwt'
+    env.fetchMock.mockRejectedValueOnce(new Error('Unauthorized'))
+
+    applyNuxtGlobals(env)
+
+    const mod = await import(`${composablePath}`)
+    const auth = mod.useAuth()
+
+    const result = await auth.fetchUser()
+
+    expect(result).toBe(false)
+    expect(tokenRef.value).toBeNull()
+    expect(userRef.value).toBeNull()
+  })
+
+  test('fetchUser returns false when no token exists', async () => {
+    const env = makeFakeEnv()
+
+    applyNuxtGlobals(env)
+
+    const mod = await import(`${composablePath}`)
+    const auth = mod.useAuth()
+
+    const result = await auth.fetchUser()
+
+    expect(result).toBe(false)
+    expect(env.fetchMock).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/tests/middleware/auth.spec.ts
+++ b/apps/web/tests/middleware/auth.spec.ts
@@ -4,7 +4,7 @@ import { join } from 'path'
 import { ref, computed } from 'vue'
 
 const webDir = join(__dirname, '../..')
-const middlewarePath = join(webDir, 'middleware', 'auth.ts')
+const middlewarePath = join(webDir, 'middleware', 'auth.global.ts')
 
 beforeEach(() => {
   jest.resetModules()
@@ -18,18 +18,19 @@ function makeRoute(path: string) {
   return { path, fullPath: path, query: {}, hash: '', params: {}, meta: {}, name: path }
 }
 
-function makeAuthEnv(token: string | null = null) {
+function makeAuthEnv(token: string | null = null, user: object | null = null) {
   const tokenRef = ref<string | null>(token)
+  const userRef = ref<object | null>(user)
   const isAuthenticated = computed(() => !!tokenRef.value)
-  return { tokenRef, isAuthenticated }
+  return { tokenRef, userRef, isAuthenticated }
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
-// AC2 — middleware/auth.ts file exists
+// AC2 — middleware/auth.global.ts file exists
 // ──────────────────────────────────────────────────────────────────────────────
 
-describe('AC2: middleware/auth.ts exists', () => {
-  test('file is present at middleware/auth.ts', () => {
+describe('AC2: middleware/auth.global.ts exists', () => {
+  test('file is present at middleware/auth.global.ts', () => {
     expect(existsSync(middlewarePath)).toBe(true)
   })
 
@@ -52,6 +53,11 @@ describe('AC2: middleware/auth.ts exists', () => {
     const source = readFileSync(middlewarePath, 'utf-8')
     expect(source).toContain('navigateTo')
   })
+
+  test('file calls fetchUser for token validation', () => {
+    const source = readFileSync(middlewarePath, 'utf-8')
+    expect(source).toContain('fetchUser')
+  })
 })
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -60,10 +66,13 @@ describe('AC2: middleware/auth.ts exists', () => {
 
 describe('AC3: unauthenticated request to protected route redirects to /login', () => {
   test('navigateTo("/login") is returned when token is null and route is /', async () => {
-    const { tokenRef, isAuthenticated } = makeAuthEnv(null)
+    const { tokenRef, userRef, isAuthenticated } = makeAuthEnv(null)
+    const fetchUserMock = jest.fn(async () => false)
     const navigateToMock = jest.fn((path: string) => ({ redirect: path }))
 
-    ;(globalThis as Record<string, unknown>).useAuth = () => ({ token: tokenRef, isAuthenticated })
+    ;(globalThis as Record<string, unknown>).useAuth = () => ({
+      token: tokenRef, user: userRef, isAuthenticated, fetchUser: fetchUserMock,
+    })
     ;(globalThis as Record<string, unknown>).navigateTo = navigateToMock
     ;(globalThis as Record<string, unknown>).defineNuxtRouteMiddleware = (fn: (to: unknown, from: unknown) => unknown) => fn
 
@@ -72,17 +81,20 @@ describe('AC3: unauthenticated request to protected route redirects to /login', 
 
     const to = makeRoute('/')
     const from = makeRoute('/login')
-    const result = middleware(to, from)
+    const result = await middleware(to, from)
 
     expect(navigateToMock).toHaveBeenCalledWith('/login')
     expect(result).toMatchObject({ redirect: '/login' })
   })
 
   test('navigateTo("/login") is returned when token is null and route is /projects', async () => {
-    const { tokenRef, isAuthenticated } = makeAuthEnv(null)
+    const { tokenRef, userRef, isAuthenticated } = makeAuthEnv(null)
+    const fetchUserMock = jest.fn(async () => false)
     const navigateToMock = jest.fn((path: string) => ({ redirect: path }))
 
-    ;(globalThis as Record<string, unknown>).useAuth = () => ({ token: tokenRef, isAuthenticated })
+    ;(globalThis as Record<string, unknown>).useAuth = () => ({
+      token: tokenRef, user: userRef, isAuthenticated, fetchUser: fetchUserMock,
+    })
     ;(globalThis as Record<string, unknown>).navigateTo = navigateToMock
     ;(globalThis as Record<string, unknown>).defineNuxtRouteMiddleware = (fn: (to: unknown, from: unknown) => unknown) => fn
 
@@ -91,17 +103,20 @@ describe('AC3: unauthenticated request to protected route redirects to /login', 
 
     const to = makeRoute('/projects')
     const from = makeRoute('/')
-    const result = middleware(to, from)
+    const result = await middleware(to, from)
 
     expect(navigateToMock).toHaveBeenCalledWith('/login')
     expect(result).toMatchObject({ redirect: '/login' })
   })
 
   test('no redirect when token is null and route is /login itself', async () => {
-    const { tokenRef, isAuthenticated } = makeAuthEnv(null)
+    const { tokenRef, userRef, isAuthenticated } = makeAuthEnv(null)
+    const fetchUserMock = jest.fn(async () => false)
     const navigateToMock = jest.fn((path: string) => ({ redirect: path }))
 
-    ;(globalThis as Record<string, unknown>).useAuth = () => ({ token: tokenRef, isAuthenticated })
+    ;(globalThis as Record<string, unknown>).useAuth = () => ({
+      token: tokenRef, user: userRef, isAuthenticated, fetchUser: fetchUserMock,
+    })
     ;(globalThis as Record<string, unknown>).navigateTo = navigateToMock
     ;(globalThis as Record<string, unknown>).defineNuxtRouteMiddleware = (fn: (to: unknown, from: unknown) => unknown) => fn
 
@@ -110,11 +125,11 @@ describe('AC3: unauthenticated request to protected route redirects to /login', 
 
     const to = makeRoute('/login')
     const from = makeRoute('/')
-    middleware(to, from)
+    await middleware(to, from)
 
     // navigateTo('/login') should NOT be called (already on /login)
     const loginRedirectCalls = navigateToMock.mock.calls.filter(
-      ([path]) => path === '/login'
+      ([path]: [string]) => path === '/login'
     )
     expect(loginRedirectCalls).toHaveLength(0)
   })
@@ -126,10 +141,13 @@ describe('AC3: unauthenticated request to protected route redirects to /login', 
 
 describe('AC4: authenticated request to /login redirects to /', () => {
   test('navigateTo("/") is returned when token is set and route is /login', async () => {
-    const { tokenRef, isAuthenticated } = makeAuthEnv('valid-jwt')
+    const { tokenRef, userRef, isAuthenticated } = makeAuthEnv('valid-jwt', { id: '1', email: 'test@test.com' })
+    const fetchUserMock = jest.fn(async () => true)
     const navigateToMock = jest.fn((path: string) => ({ redirect: path }))
 
-    ;(globalThis as Record<string, unknown>).useAuth = () => ({ token: tokenRef, isAuthenticated })
+    ;(globalThis as Record<string, unknown>).useAuth = () => ({
+      token: tokenRef, user: userRef, isAuthenticated, fetchUser: fetchUserMock,
+    })
     ;(globalThis as Record<string, unknown>).navigateTo = navigateToMock
     ;(globalThis as Record<string, unknown>).defineNuxtRouteMiddleware = (fn: (to: unknown, from: unknown) => unknown) => fn
 
@@ -138,17 +156,20 @@ describe('AC4: authenticated request to /login redirects to /', () => {
 
     const to = makeRoute('/login')
     const from = makeRoute('/')
-    const result = middleware(to, from)
+    const result = await middleware(to, from)
 
     expect(navigateToMock).toHaveBeenCalledWith('/')
     expect(result).toMatchObject({ redirect: '/' })
   })
 
   test('no redirect to / when token is set and route is /projects', async () => {
-    const { tokenRef, isAuthenticated } = makeAuthEnv('valid-jwt')
+    const { tokenRef, userRef, isAuthenticated } = makeAuthEnv('valid-jwt', { id: '1', email: 'test@test.com' })
+    const fetchUserMock = jest.fn(async () => true)
     const navigateToMock = jest.fn((path: string) => ({ redirect: path }))
 
-    ;(globalThis as Record<string, unknown>).useAuth = () => ({ token: tokenRef, isAuthenticated })
+    ;(globalThis as Record<string, unknown>).useAuth = () => ({
+      token: tokenRef, user: userRef, isAuthenticated, fetchUser: fetchUserMock,
+    })
     ;(globalThis as Record<string, unknown>).navigateTo = navigateToMock
     ;(globalThis as Record<string, unknown>).defineNuxtRouteMiddleware = (fn: (to: unknown, from: unknown) => unknown) => fn
 
@@ -157,17 +178,20 @@ describe('AC4: authenticated request to /login redirects to /', () => {
 
     const to = makeRoute('/projects')
     const from = makeRoute('/')
-    middleware(to, from)
+    await middleware(to, from)
 
     // authenticated user accessing /projects — should not redirect anywhere
     expect(navigateToMock).not.toHaveBeenCalled()
   })
 
   test('navigateTo("/") is returned when token is set and route is /register', async () => {
-    const { tokenRef, isAuthenticated } = makeAuthEnv('valid-jwt')
+    const { tokenRef, userRef, isAuthenticated } = makeAuthEnv('valid-jwt', { id: '1', email: 'test@test.com' })
+    const fetchUserMock = jest.fn(async () => true)
     const navigateToMock = jest.fn((path: string) => ({ redirect: path }))
 
-    ;(globalThis as Record<string, unknown>).useAuth = () => ({ token: tokenRef, isAuthenticated })
+    ;(globalThis as Record<string, unknown>).useAuth = () => ({
+      token: tokenRef, user: userRef, isAuthenticated, fetchUser: fetchUserMock,
+    })
     ;(globalThis as Record<string, unknown>).navigateTo = navigateToMock
     ;(globalThis as Record<string, unknown>).defineNuxtRouteMiddleware = (fn: (to: unknown, from: unknown) => unknown) => fn
 
@@ -176,10 +200,46 @@ describe('AC4: authenticated request to /login redirects to /', () => {
 
     const to = makeRoute('/register')
     const from = makeRoute('/')
-    const result = middleware(to, from)
+    const result = await middleware(to, from)
 
     // /register is also a guest-only route — authenticated users should be redirected
     expect(navigateToMock).toHaveBeenCalledWith('/')
     expect(result).toMatchObject({ redirect: '/' })
+  })
+})
+
+// ──────────────────────────────────────────────────────────────────────────────
+// AC5 — Stale token is cleared and redirects to /login
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('AC5: stale token triggers fetchUser and redirects on failure', () => {
+  test('redirects to /login when token exists but fetchUser fails (expired token)', async () => {
+    const tokenRef = ref<string | null>('expired-jwt')
+    const userRef = ref<object | null>(null)  // user not yet loaded
+    const isAuthenticated = computed(() => !!tokenRef.value)
+
+    const fetchUserMock = jest.fn(async () => {
+      // Simulate fetchUser clearing the token on 401
+      tokenRef.value = null
+      return false
+    })
+    const navigateToMock = jest.fn((path: string) => ({ redirect: path }))
+
+    ;(globalThis as Record<string, unknown>).useAuth = () => ({
+      token: tokenRef, user: userRef, isAuthenticated, fetchUser: fetchUserMock,
+    })
+    ;(globalThis as Record<string, unknown>).navigateTo = navigateToMock
+    ;(globalThis as Record<string, unknown>).defineNuxtRouteMiddleware = (fn: (to: unknown, from: unknown) => unknown) => fn
+
+    const mod = await import(`${middlewarePath}`)
+    const middleware = mod.default
+
+    const to = makeRoute('/projects')
+    const from = makeRoute('/')
+    const result = await middleware(to, from)
+
+    expect(fetchUserMock).toHaveBeenCalled()
+    expect(navigateToMock).toHaveBeenCalledWith('/login')
+    expect(result).toMatchObject({ redirect: '/login' })
   })
 })


### PR DESCRIPTION
## Summary

Fixes two auth bugs reported by William:

### Bug 1: Login error not displayed
The login page didn't show any error toast when credentials were wrong, even though the API returned `{"ret":40000,"message":"exception.40000"}` with HTTP 401.

**Root cause:** `extractApiError()` used `'data' in err` to detect ofetch's `FetchError.data`, but ofetch defines `data` as a getter via `Object.defineProperty`. While `in` should detect getters, the check was fragile.

**Fix:** Simplified to direct `(err as any).data` access. Added `statusMessage` fallback.

### Bug 2: Auto-login with stale/expired token
Opening `http://localhost:3101` bypassed login entirely if a stale `koda_token` cookie existed from a previous session.

**Root cause:** The auth middleware file was `auth.ts` (not `.global.ts`), and no page declared `definePageMeta({ middleware: 'auth' })`. The middleware never ran.

**Fix:**
- Renamed `middleware/auth.ts` → `middleware/auth.global.ts` (applies to all routes)
- Added `fetchUser()` to `useAuth` — validates token via `GET /auth/me` on first navigation
- Middleware now calls `fetchUser()` when token cookie exists but user state is empty
- Expired/invalid tokens are cleared → redirect to `/login`

### Files changed
| File | Change |
|------|--------|
| `composables/useApi.ts` | More robust `extractApiError` for ofetch FetchError |
| `composables/useAuth.ts` | Added `fetchUser()` for token validation |
| `middleware/auth.ts → auth.global.ts` | Made global + async with fetchUser call |
| `tests/middleware/auth.spec.ts` | Updated for new path + added stale token test |
| `tests/composables/useAuth.spec.ts` | Added fetchUser test cases |

### Testing
- [ ] Login with wrong credentials → error toast appears
- [ ] Open app with no cookie → redirects to /login
- [ ] Open app with valid cookie → loads dashboard
- [ ] Open app with stale/expired cookie → redirects to /login
- [ ] Login → navigate → refresh → still authenticated
