### PR TITLE
ci: parallelize checks, add bun/prisma/turbo caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,4 +103,4 @@ jobs:
         run: bun run db:generate
 
       - name: Test
-        run: bun run test -- --bail
+        run: bunx turbo run test -- --bail


### PR DESCRIPTION
## What

Optimize CI pipeline by parallelizing jobs, adding caching, and enabling Turbo remote cache.

## Why

CI currently runs typecheck → lint → test sequentially in a single job with no caching. This PR brings it in line with the nax repo's optimized CI pattern.

## How

- **Parallel matrix** for `type-check` and `lint` — run as separate simultaneous jobs
- **Bun dependency cache** — `~/.bun/install/cache` keyed on `bun.lock` hash
- **Prisma client cache** — `node_modules/.prisma` keyed on `schema.prisma` hash, skips `db:generate` on cache hit
- **Turbo remote cache** — `TURBO_TEAM`/`TURBO_TOKEN` env vars (secrets already exist from release workflow)
- **`--bail` on tests** — fail fast on first test failure
- **Tighter timeouts** — 5min for checks, 10min for tests (was 15min single job)

### Before
```
checkout → install → prisma generate → typecheck → lint → test (sequential, ~5-8 min)
```

### After
```
┌─ checks/type-check (parallel) ─┐
│  install (cached) → generate    │  ← 5 min timeout
│  (cached) → type-check          │
├─ checks/lint (parallel) ────────┤
│  install (cached) → generate    │  ← 5 min timeout
│  (cached) → lint                │
├─ test (parallel) ───────────────┤
│  install (cached) → generate    │  ← 10 min timeout
│  (cached) → test --bail         │
└─────────────────────────────────┘
All three start simultaneously. Turbo skips unchanged tasks.
```

## Testing

- [x] Tests added/updated — N/A (CI-only change)
- [x] `bun run test` passes — N/A
- [x] `bun run type-check` passes — N/A
- [x] `bun run lint` passes — N/A

## Notes

- Requires `TURBO_TEAM` and `TURBO_TOKEN` repo secrets (already configured for release workflow)
- First CI run after merge will be cold (no cache); subsequent runs benefit from all caches
