### PR TITLE
fix(ci): correct prisma cache path to apps/api/node_modules/.prisma

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         id: prisma-cache
         uses: actions/cache@v4
         with:
-          path: node_modules/.prisma
+          path: apps/api/node_modules/.prisma
           key: prisma-${{ runner.os }}-${{ hashFiles('apps/api/prisma/schema.prisma') }}
 
       - name: Generate Prisma client
@@ -95,7 +95,7 @@ jobs:
         id: prisma-cache
         uses: actions/cache@v4
         with:
-          path: node_modules/.prisma
+          path: apps/api/node_modules/.prisma
           key: prisma-${{ runner.os }}-${{ hashFiles('apps/api/prisma/schema.prisma') }}
 
       - name: Generate Prisma client


### PR DESCRIPTION
## What

Fix Prisma client cache path in CI — was pointing to wrong directory.

## Why

After merging #48, CI warned:
> Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.

The Prisma cache path was set to `node_modules/.prisma` (repo root) but in this Turbo monorepo the client generates into `apps/api/node_modules/.prisma`.

## How

Changed both `prisma-cache` steps (checks job + test job):
- **Before:** `path: node_modules/.prisma`
- **After:** `path: apps/api/node_modules/.prisma`

## Testing

- [x] Tests added/updated — N/A
- [x] `bun run test` passes — N/A
- [x] `bun run type-check` passes — N/A
- [x] `bun run lint` passes — N/A

## Notes

No functional change — Prisma generation still runs correctly. This just ensures the cache is actually saved/restored between runs.
