### PR TITLE
fix(cli): kb add sends source enum + sourceId instead of filename

### DIFF
--- a/apps/cli/src/commands/kb.spec.ts
+++ b/apps/cli/src/commands/kb.spec.ts
@@ -505,7 +505,7 @@ describe('kbCommand', () => {
       expect(allLogs).toContain('3');
     });
 
-    it('reads the file from disk and sends its content to the API', async () => {
+    it('reads the file from disk and sends content, source, and sourceId to the API', async () => {
       (KbService.add as jest.Mock).mockResolvedValue(mockAddResponse);
 
       const kbCmd = program.commands.find((cmd) => cmd.name() === 'kb');
@@ -516,8 +516,36 @@ describe('kbCommand', () => {
       expect(KbService.add).toHaveBeenCalledWith(
         expect.anything(),
         'koda',
-        expect.objectContaining({ content: mockFileContent })
+        expect.objectContaining({ content: mockFileContent, source: 'doc', sourceId: 'README.md' })
       );
+    });
+
+    it('accepts --source option to override default source type', async () => {
+      (KbService.add as jest.Mock).mockResolvedValue(mockAddResponse);
+
+      const kbCmd = program.commands.find((cmd) => cmd.name() === 'kb');
+      const addCmd = kbCmd?.commands.find((cmd) => cmd.name() === 'add');
+
+      await addCmd?.parseAsync(['node', 'test', '--project', 'koda', '--file', './README.md', '--source', 'manual']);
+
+      expect(KbService.add).toHaveBeenCalledWith(
+        expect.anything(),
+        'koda',
+        expect.objectContaining({ source: 'manual', sourceId: 'README.md' })
+      );
+    });
+
+    it('exits with code 3 for invalid --source value', async () => {
+      const kbCmd = program.commands.find((cmd) => cmd.name() === 'kb');
+      const addCmd = kbCmd?.commands.find((cmd) => cmd.name() === 'add');
+
+      try {
+        await addCmd?.parseAsync(['node', 'test', '--project', 'koda', '--file', './README.md', '--source', 'invalid']);
+      } catch {
+        // Expected
+      }
+
+      expect(exitSpy).toHaveBeenCalledWith(3);
     });
 
     it('outputs JSON with --json flag', async () => {

--- a/apps/cli/src/commands/kb.ts
+++ b/apps/cli/src/commands/kb.ts
@@ -117,10 +117,18 @@ export function kbCommand(program: Command): void {
     .description('Add a document to the knowledge base')
     .option('--project <slug>', 'Project slug')
     .option('--file <path>', 'Path to file to add')
+    .option('--source <type>', 'Source type (ticket|doc|manual)', 'doc')
     .option('--json', 'Output as JSON')
     .action(async (options) => {
       if (!options.file) {
         error('Missing required option: --file is required');
+        process.exit(3);
+        return;
+      }
+
+      const validSources = ['ticket', 'doc', 'manual'];
+      if (!validSources.includes(options.source)) {
+        error(`Invalid source type: ${options.source}. Must be one of: ${validSources.join(', ')}`);
         process.exit(3);
         return;
       }
@@ -144,7 +152,7 @@ export function kbCommand(program: Command): void {
         const fileName = basename(options.file);
 
         const client = configureClient(ctx.apiUrl, ctx.apiKey);
-        const response = await KbService.add(client, ctx.projectSlug, { content, source: fileName });
+        const response = await KbService.add(client, ctx.projectSlug, { content, source: options.source, sourceId: fileName });
         const data = unwrap(response);
 
         if (options.json) {

--- a/apps/cli/src/generated.ts
+++ b/apps/cli/src/generated.ts
@@ -284,13 +284,12 @@ export class KbService {
   static async add(
     client: AxiosInstance,
     projectSlug: string,
-    data: { content: string; source: string }
+    data: { content: string; source: 'ticket' | 'doc' | 'manual'; sourceId: string }
   ): Promise<Wrapped<KbAddResponse>> {
     // API: POST /api/projects/{slug}/kb/documents with { source, sourceId, content }
-    const sourceId = data.source; // use filename as sourceId
     const resp = await (client as any).post(`/projects/${projectSlug}/kb/documents`, {
       source: data.source,
-      sourceId,
+      sourceId: data.sourceId,
       content: data.content,
     });
     return { ret: 0, data: resp };


### PR DESCRIPTION
Fixes #51

## What

Fix `koda kb add --file` to send correct `source` enum and `sourceId` to the API.

## Why

The CLI was sending the filename as `source` (e.g. `"README.md"`) but the API validates `source` as `@IsIn(['ticket', 'doc', 'manual'])`. The API also requires `sourceId` which wasn't being sent from the CLI.

## How

### `apps/cli/src/commands/kb.ts`
- Added `--source <type>` option with default `"doc"` and validation against `ticket|doc|manual`
- Changed `KbService.add` call: `source` → `options.source`, `sourceId` → `fileName`

### `apps/cli/src/generated.ts`
- Updated `KbService.add` type signature to include `sourceId` field
- Updated implementation to use `data.sourceId` instead of duplicating `data.source`

### `apps/cli/src/commands/kb.spec.ts`
- Updated existing test to verify `source: 'doc'` and `sourceId: 'README.md'`
- Added test for `--source manual` override
- Added test for invalid `--source` → exit code 3

## Usage

```bash
koda kb add --file ./notes.md                    # source defaults to "doc"
koda kb add --file ./notes.md --source manual    # explicit source type
koda kb add --file ./notes.md --source ticket    # ticket-sourced doc
```

## Testing

- [x] `bun run test` — 34/34 kb tests pass
- [x] `bun run type-check` — clean
