### PR TITLE
fix(api): harden webhooks for S1-S5 security findings

### DIFF
--- a/apps/api/src/auth/guards/combined-auth.guard.ts
+++ b/apps/api/src/auth/guards/combined-auth.guard.ts
@@ -35,7 +35,8 @@ export class CombinedAuthGuard extends JwtAuthGuard {
       const isAgent = await this.tryApiKey(context);
       this.combinedLogger.debug(`tryApiKey result: ${isAgent}`);
       if (isAgent) {
-        this.combinedLogger.debug(`API key auth succeeded, req.user=${JSON.stringify(request['user'])}`);
+        const userId = (request['user'] as { id?: string } | undefined)?.id ?? 'unknown';
+        this.combinedLogger.debug(`API key auth succeeded, userId=${userId}`);
         return true;
       }
     } catch (e: unknown) {

--- a/apps/api/src/ci-webhook/ci-webhook.controller.spec.ts
+++ b/apps/api/src/ci-webhook/ci-webhook.controller.spec.ts
@@ -2,11 +2,13 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { CiWebhookController } from './ci-webhook.controller';
 import { CiWebhookService } from './ci-webhook.service';
 import { CiWebhookPayloadDto } from './ci-webhook.dto';
+import { createHmac } from 'node:crypto';
 
 describe('CiWebhookController', () => {
   let controller: CiWebhookController;
 
   const mockCiWebhookService = {
+    getWebhookSecret: jest.fn(),
     processCiWebhook: jest.fn(),
   };
 
@@ -26,6 +28,7 @@ describe('CiWebhookController', () => {
   });
 
   describe('handleCiWebhook', () => {
+    const secret = 'test-secret';
     const validPayload: CiWebhookPayloadDto = {
       event: 'pipeline_failed',
       pipeline: { id: '12345', url: 'https://github.com/org/repo/actions/runs/12345' },
@@ -42,23 +45,29 @@ describe('CiWebhookController', () => {
         message: 'Created ticket for CI failure: AuthService.validateToken',
       };
 
+      mockCiWebhookService.getWebhookSecret.mockResolvedValue(secret);
       mockCiWebhookService.processCiWebhook.mockResolvedValue(expectedResult);
 
-      const result = await controller.handleCiWebhook('koda', validPayload);
+      const signature = `sha256=${createHmac('sha256', secret).update(JSON.stringify(validPayload)).digest('hex')}`;
+      const result = await controller.handleCiWebhook('koda', validPayload, signature);
 
       expect(result).toHaveProperty('data');
       expect(result.data).toEqual(expectedResult);
+      expect(mockCiWebhookService.getWebhookSecret).toHaveBeenCalledWith('koda');
       expect(mockCiWebhookService.processCiWebhook).toHaveBeenCalledWith('koda', validPayload);
     });
 
     it('should pass project slug to service', async () => {
+      mockCiWebhookService.getWebhookSecret.mockResolvedValue(secret);
       mockCiWebhookService.processCiWebhook.mockResolvedValue({
         success: true,
         message: 'ignored',
       });
 
-      await controller.handleCiWebhook('my-project', validPayload);
+      const signature = `sha256=${createHmac('sha256', secret).update(JSON.stringify(validPayload)).digest('hex')}`;
+      await controller.handleCiWebhook('my-project', validPayload, signature);
 
+      expect(mockCiWebhookService.getWebhookSecret).toHaveBeenCalledWith('my-project');
       expect(mockCiWebhookService.processCiWebhook).toHaveBeenCalledWith(
         'my-project',
         validPayload,
@@ -66,12 +75,14 @@ describe('CiWebhookController', () => {
     });
 
     it('should pass full payload to service', async () => {
+      mockCiWebhookService.getWebhookSecret.mockResolvedValue(secret);
       mockCiWebhookService.processCiWebhook.mockResolvedValue({
         success: true,
         message: 'Created ticket',
       });
 
-      await controller.handleCiWebhook('koda', validPayload);
+      const signature = `sha256=${createHmac('sha256', secret).update(JSON.stringify(validPayload)).digest('hex')}`;
+      await controller.handleCiWebhook('koda', validPayload, signature);
 
       expect(mockCiWebhookService.processCiWebhook).toHaveBeenCalledWith('koda', validPayload);
     });
@@ -87,23 +98,43 @@ describe('CiWebhookController', () => {
         message: "Event 'pipeline_success' ignored - only 'pipeline_failed' events are processed",
       };
 
+      mockCiWebhookService.getWebhookSecret.mockResolvedValue(secret);
       mockCiWebhookService.processCiWebhook.mockResolvedValue(expectedResult);
 
-      const result = await controller.handleCiWebhook('koda', successPayload);
+      const signature = `sha256=${createHmac('sha256', secret).update(JSON.stringify(successPayload)).digest('hex')}`;
+      const result = await controller.handleCiWebhook('koda', successPayload, signature);
 
       expect(result.data).toEqual(expectedResult);
     });
 
     it('should throw when service throws NotFoundAppException', async () => {
+      mockCiWebhookService.getWebhookSecret.mockResolvedValue(secret);
       mockCiWebhookService.processCiWebhook.mockRejectedValue(new Error('Not found'));
+      const signature = `sha256=${createHmac('sha256', secret).update(JSON.stringify(validPayload)).digest('hex')}`;
 
-      await expect(controller.handleCiWebhook('nonexistent', validPayload)).rejects.toThrow('Not found');
+      await expect(controller.handleCiWebhook('nonexistent', validPayload, signature)).rejects.toThrow('Not found');
     });
 
     it('should throw when service throws ValidationAppException', async () => {
+      mockCiWebhookService.getWebhookSecret.mockResolvedValue(secret);
       mockCiWebhookService.processCiWebhook.mockRejectedValue(new Error('Validation error'));
+      const signature = `sha256=${createHmac('sha256', secret).update(JSON.stringify(validPayload)).digest('hex')}`;
 
-      await expect(controller.handleCiWebhook('koda', validPayload)).rejects.toThrow('Validation error');
+      await expect(controller.handleCiWebhook('koda', validPayload, signature)).rejects.toThrow('Validation error');
+    });
+
+    it('should throw when webhook secret is missing', async () => {
+      mockCiWebhookService.getWebhookSecret.mockResolvedValue(null);
+
+      await expect(controller.handleCiWebhook('koda', validPayload, '')).rejects.toThrow();
+      expect(mockCiWebhookService.processCiWebhook).not.toHaveBeenCalled();
+    });
+
+    it('should throw when signature is invalid', async () => {
+      mockCiWebhookService.getWebhookSecret.mockResolvedValue(secret);
+
+      await expect(controller.handleCiWebhook('koda', validPayload, 'sha256=invalid')).rejects.toThrow();
+      expect(mockCiWebhookService.processCiWebhook).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/ci-webhook/ci-webhook.controller.ts
+++ b/apps/api/src/ci-webhook/ci-webhook.controller.ts
@@ -1,9 +1,11 @@
-import { Controller, Post, Body, Param, HttpCode } from '@nestjs/common';
+import { Controller, Post, Body, Param, HttpCode, Headers } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { Public } from '@nathapp/nestjs-auth';
+import { AuthException } from '@nathapp/nestjs-common';
 import { CiWebhookService } from './ci-webhook.service';
 import { CiWebhookPayloadDto, CiWebhookResponseDto } from './ci-webhook.dto';
 import { JsonResponse } from '@nathapp/nestjs-common';
+import { createHmac, timingSafeEqual } from 'node:crypto';
 
 @ApiTags('ci-webhooks')
 @Controller()
@@ -20,8 +22,35 @@ export class CiWebhookController {
   async handleCiWebhook(
     @Param('slug') slug: string,
     @Body() payload: CiWebhookPayloadDto,
+    @Headers('x-ci-signature') signature?: string,
   ) {
+    const secret = await this.ciWebhookService.getWebhookSecret(slug);
+    if (!secret) {
+      throw new AuthException({}, 'ci_webhook');
+    }
+
+    const isValid = this.verifySignature(JSON.stringify(payload), signature ?? '', secret);
+    if (!isValid) {
+      throw new AuthException({}, 'ci_webhook');
+    }
+
     const result = await this.ciWebhookService.processCiWebhook(slug, payload);
     return JsonResponse.Ok(result);
+  }
+
+  private verifySignature(payload: string, signature: string, secret: string): boolean {
+    try {
+      const expectedSignature = `sha256=${createHmac('sha256', secret).update(payload).digest('hex')}`;
+      const expected = Buffer.from(expectedSignature);
+      const received = Buffer.from(signature);
+
+      if (expected.length !== received.length) {
+        return false;
+      }
+
+      return timingSafeEqual(expected, received);
+    } catch {
+      return false;
+    }
   }
 }

--- a/apps/api/src/ci-webhook/ci-webhook.service.ts
+++ b/apps/api/src/ci-webhook/ci-webhook.service.ts
@@ -12,6 +12,22 @@ export class CiWebhookService {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private get db() { return this.prisma.client; }
 
+  async getWebhookSecret(projectSlug: string): Promise<string | null> {
+    const project = await this.db.project.findUnique({
+      where: { slug: projectSlug },
+      select: {
+        ciWebhookToken: true,
+        deletedAt: true,
+      },
+    });
+
+    if (!project || project.deletedAt) {
+      throw new NotFoundAppException({}, 'projects');
+    }
+
+    return project.ciWebhookToken ?? null;
+  }
+
   async processCiWebhook(projectSlug: string, payload: CiWebhookPayloadDto) {
     // Find project by slug
     const project = await this.db.project.findUnique({

--- a/apps/api/src/rag/entity-store.ts
+++ b/apps/api/src/rag/entity-store.ts
@@ -6,7 +6,7 @@
  */
 import { Injectable, Optional } from '@nestjs/common';
 import { PrismaService } from '@nathapp/nestjs-prisma';
-import type { PrismaClient } from '@prisma/client';
+import { Prisma, type PrismaClient } from '@prisma/client';
 
 export interface Entity {
   id: string;
@@ -151,10 +151,9 @@ export class EntityStore {
     if (this.getProjectCodeDocuments) {
       nodes = await this.getProjectCodeDocuments(projectId);
     } else {
-      const docs = await this.prisma.client.$queryRaw<Array<{ id: string; label: string; type: string; source_file?: string }>>`
-        SELECT id, label, type, source_file FROM code_document WHERE project_id = ${projectId}
-      `;
-      nodes = docs;
+      nodes = await this.prisma.client.$queryRaw<Array<{ id: string; label: string; type: string; source_file?: string }>>(
+        Prisma.sql`SELECT id, label, type, source_file FROM code_document WHERE project_id = ${projectId}`,
+      );
     }
 
     for (const node of nodes) {

--- a/apps/api/src/vcs/vcs-webhook.controller.ts
+++ b/apps/api/src/vcs/vcs-webhook.controller.ts
@@ -30,10 +30,14 @@ export class VcsWebhookController {
     const project = await this.projectsService.findBySlug(slug);
     const connection = await this.vcsConnectionService.getFullByProject(project.id);
 
+    if (!connection.webhookSecret) {
+      throw new AuthException({}, 'vcs_webhook');
+    }
+
     const isValid = this.webhookService.verifySignature(
       JSON.stringify(payload),
       signature || '',
-      connection.webhookSecret || '',
+      connection.webhookSecret,
     );
 
     if (!isValid) {

--- a/apps/api/src/webhook/webhook.controller.ts
+++ b/apps/api/src/webhook/webhook.controller.ts
@@ -12,10 +12,10 @@ import {
   ApiOperation,
   ApiResponse,
 } from '@nestjs/swagger';
-import { Public } from '@nathapp/nestjs-auth';
+import { RequiredPermission } from '@nathapp/nestjs-auth';
 import { WebhookService } from './webhook.service';
 import { CreateWebhookDto } from './webhook.dto';
-import { JsonResponse, NotFoundAppException } from '@nathapp/nestjs-common';
+import { JsonResponse } from '@nathapp/nestjs-common';
 
 @ApiTags('webhooks')
 @Controller()
@@ -24,7 +24,7 @@ export class WebhookController {
 
   @Post('projects/:slug/webhooks')
   @HttpCode(201)
-  @Public()
+  @RequiredPermission('ADMIN')
   @ApiOperation({ summary: 'Register a webhook for a project' })
   @ApiResponse({ status: 201, description: 'Webhook registered' })
   @ApiResponse({ status: 400, description: 'Invalid request data' })
@@ -39,7 +39,7 @@ export class WebhookController {
   }
 
   @Get('projects/:slug/webhooks')
-  @Public()
+  @RequiredPermission('ADMIN')
   @ApiOperation({ summary: 'List all webhooks for a project' })
   @ApiResponse({ status: 200, description: 'List of webhooks' })
   @ApiResponse({ status: 404, description: 'Project not found' })
@@ -50,7 +50,7 @@ export class WebhookController {
 
   @Delete('api/webhooks/:id')
   @HttpCode(204)
-  @Public()
+  @RequiredPermission('ADMIN')
   @ApiOperation({ summary: 'Remove a webhook' })
   @ApiResponse({ status: 204, description: 'Webhook deleted' })
   @ApiResponse({ status: 404, description: 'Webhook not found' })

--- a/apps/api/src/webhook/webhook.service.ts
+++ b/apps/api/src/webhook/webhook.service.ts
@@ -23,6 +23,13 @@ export class WebhookService {
   async findAll(projectId: string) {
     return this.db.webhook.findMany({
       where: { projectId },
+      select: {
+        id: true,
+        projectId: true,
+        url: true,
+        events: true,
+        createdAt: true,
+      },
       orderBy: { createdAt: 'desc' },
     });
   }

--- a/apps/api/test/e2e/api-endpoint/endpoint.e2e.spec.ts
+++ b/apps/api/test/e2e/api-endpoint/endpoint.e2e.spec.ts
@@ -20,6 +20,7 @@ import { AppFactory, NathApplication } from '@nathapp/nestjs-app';
 import { PrismaService } from '@nathapp/nestjs-prisma';
 import { PrismaClient, ProjectMember } from '@prisma/client';
 import { CombinedAuthGuard } from '../../../src/auth/guards/combined-auth.guard';
+import { createHmac } from 'node:crypto';
 
 const DATABASE_URL = process.env.DATABASE_URL;
 const describeIntegration = DATABASE_URL ? describe : describe.skip;
@@ -1766,23 +1767,37 @@ describeIntegration('API Integration Tests', () => {
   // ─────────────────────────────────────────────────────────────────
 
   describe('CI Webhooks', () => {
+    const ciWebhookSecret = 'ci-webhook-secret-for-e2e-tests-123456';
+
+    beforeAll(async () => {
+      const prisma = app.get<PrismaService<PrismaClient>>(PrismaService);
+      await prisma.client.project.update({
+        where: { slug: projectSlug },
+        data: { ciWebhookToken: ciWebhookSecret },
+      });
+    });
+
     it('POST /api/projects/:slug/ci-webhook — creates ticket on pipeline failure', async () => {
+      const payload = {
+        event: 'pipeline_failed',
+        pipeline: {
+          id: '12345',
+          url: 'https://github.com/org/repo/actions/runs/12345',
+        },
+        commit: {
+          sha: 'abc123def456',
+          message: 'feat: add CI webhook support',
+        },
+        failures: [
+          { test: 'AuthService.validateToken', file: 'apps/api/src/auth/auth.service.ts', line: 87 },
+        ],
+      };
+      const signature = `sha256=${createHmac('sha256', ciWebhookSecret).update(JSON.stringify(payload)).digest('hex')}`;
+
       const res = await request(httpServer)
         .post(`/api/projects/${projectSlug}/ci-webhook`)
-        .send({
-          event: 'pipeline_failed',
-          pipeline: {
-            id: '12345',
-            url: 'https://github.com/org/repo/actions/runs/12345',
-          },
-          commit: {
-            sha: 'abc123def456',
-            message: 'feat: add CI webhook support',
-          },
-          failures: [
-            { test: 'AuthService.validateToken', file: 'apps/api/src/auth/auth.service.ts', line: 87 },
-          ],
-        })
+        .set('x-ci-signature', signature)
+        .send(payload)
         .expect(200);
 
       const data = body<{ success: boolean; ticketRef: string; message: string }>(res);


### PR DESCRIPTION
## Summary
- secure webhook create/list/delete endpoints with admin permission checks
- add CI webhook HMAC signature verification and project secret lookup
- fail closed when VCS webhook secret is missing
- reduce auth guard debug log exposure to only userId
- use explicit Prisma.sql parameterized query in entity store
- redact webhook secrets from webhook list responses
- update CI webhook unit tests and API e2e tests for signed webhook flow

## Validation
- bun run test
- bun run lint
- bun run type-check

## Notes
- CI webhook now requires x-ci-signature for existing projects with ciWebhookToken configured
- nonexistent projects still return 404 in CI webhook e2e flow