### PR TITLE
fix(api): implement S6-S8 security hardening

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -9,9 +9,9 @@ DATABASE_PROVIDER=sqlite
 
 # JWT Auth
 JWT_SECRET=your-jwt-secret-here
-JWT_EXPIRES_IN=7d
+JWT_EXPIRES_IN=15m
 JWT_REFRESH_SECRET=your-jwt-refresh-secret-here
-JWT_REFRESH_EXPIRES_IN=30d
+JWT_REFRESH_EXPIRES_IN=7d
 
 # Agent API Key
 API_KEY_SECRET=your-api-key-secret-here

--- a/apps/api/.env.test
+++ b/apps/api/.env.test
@@ -1,8 +1,9 @@
 DATABASE_PROVIDER="sqlite"
 DATABASE_URL="file:./koda-test.db"
 JWT_SECRET="test-jwt-secret"
-JWT_EXPIRES_IN="7d"
+JWT_EXPIRES_IN="15m"
 JWT_REFRESH_SECRET="test-jwt-refresh-secret"
+JWT_REFRESH_EXPIRES_IN="7d"
 API_KEY_SECRET="test-api-key-secret"
 API_PORT=3101
 PRISMA_USER_CONSENT_FOR_DANGEROUS_AI_ACTION="yes"

--- a/apps/api/src/auth/auth.controller.spec.ts
+++ b/apps/api/src/auth/auth.controller.spec.ts
@@ -50,7 +50,7 @@ describe('AuthController', () => {
       const registerDto = {
         email: 'newuser@example.com',
         name: 'New User',
-        password: 'password123',
+        password: 'Password123!',
       };
 
       mockAuthService.register.mockResolvedValue(mockTokenResponse);
@@ -66,7 +66,7 @@ describe('AuthController', () => {
       const registerDto = {
         email: 'newuser@example.com',
         name: 'New User',
-        password: 'password123',
+        password: 'Password123!',
       };
 
       const newUserResponse = {
@@ -100,7 +100,7 @@ describe('AuthController', () => {
     it('should login user and return tokens', async () => {
       const loginDto = {
         email: mockUser.email,
-        password: 'password123',
+        password: 'Password123!',
       };
 
       mockAuthService.login.mockResolvedValue(mockTokenResponse);
@@ -115,7 +115,7 @@ describe('AuthController', () => {
     it('should return user, accessToken, and refreshToken', async () => {
       const loginDto = {
         email: mockUser.email,
-        password: 'password123',
+        password: 'Password123!',
       };
 
       mockAuthService.login.mockResolvedValue(mockTokenResponse);
@@ -142,7 +142,7 @@ describe('AuthController', () => {
     it('should return 401 for non-existent user', async () => {
       const loginDto = {
         email: 'nonexistent@example.com',
-        password: 'password123',
+        password: 'Password123!',
       };
 
       mockAuthService.login.mockRejectedValue(new AuthException());

--- a/apps/api/src/auth/auth.module.ts
+++ b/apps/api/src/auth/auth.module.ts
@@ -26,13 +26,13 @@ import { KodaCaslAbilityFactory } from './casl/koda-casl-ability.factory';
           jwtOptions: {
             secret: authConfig?.jwtSecret,
             signOption: {
-              expiresIn: authConfig?.jwtExpiresIn ?? '7d',
+              expiresIn: authConfig?.jwtExpiresIn ?? '15m',
             },
           },
           refreshJwtOptions: {
             secret: authConfig?.jwtRefreshSecret,
             signOption: {
-              expiresIn: authConfig?.jwtRefreshExpiresIn ?? '30d',
+              expiresIn: authConfig?.jwtRefreshExpiresIn ?? '7d',
             },
           },
         };

--- a/apps/api/src/auth/auth.service.spec.ts
+++ b/apps/api/src/auth/auth.service.spec.ts
@@ -72,7 +72,7 @@ describe('AuthService', () => {
       const registerDto = {
         email: 'newuser@example.com',
         name: 'New User',
-        password: 'password123',
+        password: 'Password123!',
       };
 
       mockPrismaService.client.user.create.mockResolvedValue(mockUser);
@@ -98,7 +98,7 @@ describe('AuthService', () => {
       const registerDto = {
         email: 'newuser@example.com',
         name: 'New User',
-        password: 'password123',
+        password: 'Password123!',
       };
 
       mockPrismaService.client.user.create.mockResolvedValue(mockUser);
@@ -116,7 +116,7 @@ describe('AuthService', () => {
 
   describe('login', () => {
     it('should return tokens for valid credentials', async () => {
-      const password = 'password123';
+      const password = 'Password123!';
       const hashedPassword = await bcrypt.hash(password, 12);
       const userWithHash = { ...mockUser, passwordHash: hashedPassword };
 
@@ -150,7 +150,7 @@ describe('AuthService', () => {
       await expect(
         service.login({
           email: 'nonexistent@example.com',
-          password: 'password123',
+          password: 'Password123!',
         }),
       ).rejects.toThrow(AppException);
     });

--- a/apps/api/src/auth/dto/login.dto.ts
+++ b/apps/api/src/auth/dto/login.dto.ts
@@ -6,7 +6,7 @@ export class LoginDto {
   @IsEmail({}, { message: '$t(common.validation.isEmail)' })
   declare email: string;
 
-  @ApiProperty({ example: 'password123' })
+  @ApiProperty({ example: 'Password123!' })
   @IsString({ message: '$t(common.validation.isString)' })
   declare password: string;
 }

--- a/apps/api/src/auth/dto/register.dto.spec.ts
+++ b/apps/api/src/auth/dto/register.dto.spec.ts
@@ -1,0 +1,38 @@
+import { validate } from 'class-validator';
+import { RegisterDto } from './register.dto';
+
+describe('RegisterDto', () => {
+  it('accepts a strong password', async () => {
+    const dto = new RegisterDto();
+    dto.email = 'user@example.com';
+    dto.name = 'User';
+    dto.password = 'StrongPass123!';
+
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('rejects passwords shorter than 12 characters', async () => {
+    const dto = new RegisterDto();
+    dto.email = 'user@example.com';
+    dto.name = 'User';
+    dto.password = 'Abc123!xyz';
+
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+    const passwordError = errors.find((error) => error.property === 'password');
+    expect(passwordError?.constraints).toHaveProperty('minLength');
+  });
+
+  it('rejects passwords missing required complexity', async () => {
+    const dto = new RegisterDto();
+    dto.email = 'user@example.com';
+    dto.name = 'User';
+    dto.password = 'Strongpass1234';
+
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+    const passwordError = errors.find((error) => error.property === 'password');
+    expect(passwordError?.constraints).toHaveProperty('matches');
+  });
+});

--- a/apps/api/src/auth/dto/register.dto.ts
+++ b/apps/api/src/auth/dto/register.dto.ts
@@ -1,4 +1,4 @@
-import { IsEmail, IsString, MinLength } from 'class-validator';
+import { IsEmail, IsString, MinLength, Matches } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class RegisterDto {
@@ -11,8 +11,11 @@ export class RegisterDto {
   @MinLength(1, { message: '$t(common.validation.minLength)' })
   declare name: string;
 
-  @ApiProperty({ example: 'password123' })
+  @ApiProperty({ example: 'StrongPass123!' })
   @IsString({ message: '$t(common.validation.isString)' })
-  @MinLength(8, { message: '$t(common.validation.minLength)' })
+  @MinLength(12, { message: '$t(common.validation.minLength)' })
+  @Matches(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z\d]).+$/, {
+    message: '$t(common.validation.passwordComplexity)',
+  })
   declare password: string;
 }

--- a/apps/api/src/config/auth.config.spec.ts
+++ b/apps/api/src/config/auth.config.spec.ts
@@ -1,0 +1,57 @@
+/// <reference types="jest" />
+
+import { authConfig } from './auth.config';
+
+describe('authConfig defaults', () => {
+  it('uses hardened defaults when expiry env vars are unset', () => {
+    const prevJwtExpiresIn = process.env['JWT_EXPIRES_IN'];
+    const prevJwtRefreshExpiresIn = process.env['JWT_REFRESH_EXPIRES_IN'];
+
+    delete process.env['JWT_EXPIRES_IN'];
+    delete process.env['JWT_REFRESH_EXPIRES_IN'];
+
+    try {
+      const config = authConfig();
+      expect(config.jwtExpiresIn).toBe('15m');
+      expect(config.jwtRefreshExpiresIn).toBe('7d');
+    } finally {
+      if (prevJwtExpiresIn !== undefined) {
+        process.env['JWT_EXPIRES_IN'] = prevJwtExpiresIn;
+      } else {
+        delete process.env['JWT_EXPIRES_IN'];
+      }
+
+      if (prevJwtRefreshExpiresIn !== undefined) {
+        process.env['JWT_REFRESH_EXPIRES_IN'] = prevJwtRefreshExpiresIn;
+      } else {
+        delete process.env['JWT_REFRESH_EXPIRES_IN'];
+      }
+    }
+  });
+
+  it('uses explicit env values when provided', () => {
+    const prevJwtExpiresIn = process.env['JWT_EXPIRES_IN'];
+    const prevJwtRefreshExpiresIn = process.env['JWT_REFRESH_EXPIRES_IN'];
+
+    process.env['JWT_EXPIRES_IN'] = '1h';
+    process.env['JWT_REFRESH_EXPIRES_IN'] = '14d';
+
+    try {
+      const config = authConfig();
+      expect(config.jwtExpiresIn).toBe('1h');
+      expect(config.jwtRefreshExpiresIn).toBe('14d');
+    } finally {
+      if (prevJwtExpiresIn !== undefined) {
+        process.env['JWT_EXPIRES_IN'] = prevJwtExpiresIn;
+      } else {
+        delete process.env['JWT_EXPIRES_IN'];
+      }
+
+      if (prevJwtRefreshExpiresIn !== undefined) {
+        process.env['JWT_REFRESH_EXPIRES_IN'] = prevJwtRefreshExpiresIn;
+      } else {
+        delete process.env['JWT_REFRESH_EXPIRES_IN'];
+      }
+    }
+  });
+});

--- a/apps/api/src/config/auth.config.ts
+++ b/apps/api/src/config/auth.config.ts
@@ -2,8 +2,8 @@ import { registerAs } from '@nestjs/config';
 
 export const authConfig = registerAs('auth', () => ({
   jwtSecret: process.env['JWT_SECRET'],
-  jwtExpiresIn: process.env['JWT_EXPIRES_IN'] ?? '7d',
+  jwtExpiresIn: process.env['JWT_EXPIRES_IN'] ?? '15m',
   jwtRefreshSecret: process.env['JWT_REFRESH_SECRET'],
-  jwtRefreshExpiresIn: process.env['JWT_REFRESH_EXPIRES_IN'] ?? '30d',
+  jwtRefreshExpiresIn: process.env['JWT_REFRESH_EXPIRES_IN'] ?? '7d',
   apiKeySecret: process.env['API_KEY_SECRET'],
 }));

--- a/apps/api/src/config/env.validation.ts
+++ b/apps/api/src/config/env.validation.ts
@@ -12,9 +12,9 @@ const envSchema = Joi.object({
     .valid('sqlite', 'postgresql', 'mysql')
     .default('sqlite'),
   JWT_SECRET: Joi.string().required(),
-  JWT_EXPIRES_IN: Joi.string().default('7d'),
+  JWT_EXPIRES_IN: Joi.string().default('15m'),
   JWT_REFRESH_SECRET: Joi.string().required(),
-  JWT_REFRESH_EXPIRES_IN: Joi.string().default('30d'),
+  JWT_REFRESH_EXPIRES_IN: Joi.string().default('7d'),
   API_KEY_SECRET: Joi.string().required(),
   VCS_ENCRYPTION_KEY: Joi.string().hex().length(64).optional(),
   VCS_DEFAULT_POLLING_INTERVAL_MS: Joi.number().integer().min(60000).optional(),

--- a/apps/api/src/i18n/en/common.json
+++ b/apps/api/src/i18n/en/common.json
@@ -7,7 +7,9 @@
     "isString": "Must be a string",
     "isEnum": "Invalid value",
     "isUrl": "Must be a valid URL",
-    "isBoolean": "Must be a boolean"
+    "isBoolean": "Must be a boolean",
+    "passwordComplexity": "Password must include uppercase, lowercase, number, and symbol",
+    "webhookSecretMinLength": "Webhook secret must be at least 32 characters"
   },
   "errors": {
     "notFound": "Resource not found",

--- a/apps/api/src/i18n/zh/common.json
+++ b/apps/api/src/i18n/zh/common.json
@@ -7,7 +7,9 @@
     "isString": "Must be a string",
     "isEnum": "Invalid value",
     "isUrl": "Must be a valid URL",
-    "isBoolean": "Must be a boolean"
+    "isBoolean": "Must be a boolean",
+    "passwordComplexity": "密码必须包含大写字母、小写字母、数字和特殊字符",
+    "webhookSecretMinLength": "Webhook 密钥长度至少为 32 个字符"
   },
   "errors": {
     "notFound": "Resource not found",

--- a/apps/api/src/projects/dto/update-project.dto.spec.ts
+++ b/apps/api/src/projects/dto/update-project.dto.spec.ts
@@ -1,0 +1,25 @@
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { UpdateProjectDto } from './update-project.dto';
+
+describe('UpdateProjectDto', () => {
+  it('accepts ciWebhookToken with length >= 32', async () => {
+    const dto = plainToInstance(UpdateProjectDto, {
+      ciWebhookToken: '12345678901234567890123456789012',
+    });
+
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('rejects ciWebhookToken shorter than 32 chars', async () => {
+    const dto = plainToInstance(UpdateProjectDto, {
+      ciWebhookToken: 'short-token',
+    });
+
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+    const ciTokenError = errors.find((error) => error.property === 'ciWebhookToken');
+    expect(ciTokenError?.constraints).toHaveProperty('minLength');
+  });
+});

--- a/apps/api/src/projects/dto/update-project.dto.ts
+++ b/apps/api/src/projects/dto/update-project.dto.ts
@@ -83,6 +83,7 @@ export class UpdateProjectDto {
   })
   @IsOptional()
   @IsString({ message: '$t(common.validation.isString)' })
+  @MinLength(32, { message: '$t(common.validation.webhookSecretMinLength)' })
   ciWebhookToken?: string;
 
   @ApiPropertyOptional({

--- a/apps/api/src/vcs/dto/update-vcs-connection.dto.ts
+++ b/apps/api/src/vcs/dto/update-vcs-connection.dto.ts
@@ -1,4 +1,4 @@
-import { IsArray, IsEnum, IsInt, IsOptional, IsString, Min } from 'class-validator';
+import { IsArray, IsEnum, IsInt, IsOptional, IsString, Min, MinLength } from 'class-validator';
 import { VcsSyncModeType } from './create-vcs-connection.dto';
 
 export class UpdateVcsConnectionDto {
@@ -22,5 +22,6 @@ export class UpdateVcsConnectionDto {
 
   @IsOptional()
   @IsString()
+  @MinLength(32, { message: '$t(common.validation.webhookSecretMinLength)' })
   webhookSecret?: string;
 }

--- a/apps/api/src/vcs/dto/vcs-connection.dto.spec.ts
+++ b/apps/api/src/vcs/dto/vcs-connection.dto.spec.ts
@@ -231,6 +231,26 @@ describe('VCS Connection DTOs', () => {
       expect(errors[0].property).toBe('allowedAuthors');
       expect(errors[0].constraints).toHaveProperty('isArray');
     });
+
+    it('should validate webhookSecret with length >= 32', async () => {
+      const dto = plainToInstance(UpdateVcsConnectionDto, {
+        webhookSecret: '12345678901234567890123456789012',
+      });
+
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should reject webhookSecret shorter than 32 chars', async () => {
+      const dto = plainToInstance(UpdateVcsConnectionDto, {
+        webhookSecret: 'too-short-secret',
+      });
+
+      const errors = await validate(dto);
+      expect(errors.length).toBeGreaterThan(0);
+      const webhookSecretError = errors.find((error) => error.property === 'webhookSecret');
+      expect(webhookSecretError?.constraints).toHaveProperty('minLength');
+    });
   });
 
   describe('VcsConnectionResponseDto', () => {

--- a/apps/api/src/webhook/webhook.dto.spec.ts
+++ b/apps/api/src/webhook/webhook.dto.spec.ts
@@ -1,0 +1,44 @@
+import { validate } from 'class-validator';
+import { CreateWebhookDto, UpdateWebhookDto } from './webhook.dto';
+
+describe('Webhook DTO validation', () => {
+  it('accepts create dto with secret length >= 32', async () => {
+    const dto = new CreateWebhookDto();
+    dto.url = 'https://example.com/webhook';
+    dto.secret = '12345678901234567890123456789012';
+    dto.events = ['STATUS_CHANGE'];
+
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('rejects create dto with secret length < 32', async () => {
+    const dto = new CreateWebhookDto();
+    dto.url = 'https://example.com/webhook';
+    dto.secret = '1234567890123456789012345678901';
+    dto.events = ['STATUS_CHANGE'];
+
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+    const secretError = errors.find((error) => error.property === 'secret');
+    expect(secretError?.constraints).toHaveProperty('minLength');
+  });
+
+  it('allows update dto when secret is omitted', async () => {
+    const dto = new UpdateWebhookDto();
+    dto.active = true;
+
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('rejects update dto with provided secret length < 32', async () => {
+    const dto = new UpdateWebhookDto();
+    dto.secret = 'short-secret';
+
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+    const secretError = errors.find((error) => error.property === 'secret');
+    expect(secretError?.constraints).toHaveProperty('minLength');
+  });
+});

--- a/apps/api/src/webhook/webhook.dto.ts
+++ b/apps/api/src/webhook/webhook.dto.ts
@@ -1,10 +1,11 @@
-import { IsUrl, IsString, IsArray, IsBoolean, IsOptional } from 'class-validator';
+import { IsUrl, IsString, IsArray, IsBoolean, IsOptional, MinLength } from 'class-validator';
 
 export class CreateWebhookDto {
   @IsUrl()
   url: string;
 
   @IsString()
+  @MinLength(32, { message: '$t(common.validation.webhookSecretMinLength)' })
   secret: string;
 
   @IsArray()
@@ -19,6 +20,7 @@ export class UpdateWebhookDto {
 
   @IsOptional()
   @IsString()
+  @MinLength(32, { message: '$t(common.validation.webhookSecretMinLength)' })
   secret?: string;
 
   @IsOptional()

--- a/apps/api/test-vcs-setup.js
+++ b/apps/api/test-vcs-setup.js
@@ -18,7 +18,7 @@ async function test() {
     // Register user
     const registerRes = await request(httpServer)
       .post('/api/auth/register')
-      .send({ email: `test-${Date.now()}@koda.test`, name: 'Test', password: 'Test1234!' });
+      .send({ email: `test-${Date.now()}@koda.test`, name: 'Test', password: 'TestUser1234!' });
     
     console.log('Register status:', registerRes.status);
     console.log('Register body:', registerRes.body);

--- a/apps/api/test/e2e/agents.e2e.spec.ts
+++ b/apps/api/test/e2e/agents.e2e.spec.ts
@@ -50,7 +50,7 @@ describeIntegration('Agents API E2E', () => {
 
     const adminRegisterRes = await request(httpServer)
       .post('/api/auth/register')
-      .send({ email: 'agents-admin@koda.test', name: 'Agents Admin', password: 'Admin1234!' })
+      .send({ email: 'agents-admin@koda.test', name: 'Agents Admin', password: 'Admin1234!Aa' })
       .expect(201);
 
     const prisma = app.get<PrismaService<PrismaClient>>(PrismaService);
@@ -63,14 +63,14 @@ describeIntegration('Agents API E2E', () => {
 
     const adminLoginRes = await request(httpServer)
       .post('/api/auth/login')
-      .send({ email: 'agents-admin@koda.test', password: 'Admin1234!' })
+      .send({ email: 'agents-admin@koda.test', password: 'Admin1234!Aa' })
       .expect(200);
 
     adminAccessToken = body<{ accessToken: string }>(adminLoginRes).accessToken;
 
     const memberRegisterRes = await request(httpServer)
       .post('/api/auth/register')
-      .send({ email: 'agents-member@koda.test', name: 'Agents Member', password: 'Member1234!' })
+      .send({ email: 'agents-member@koda.test', name: 'Agents Member', password: 'Member1234!Aa' })
       .expect(201);
 
     memberAccessToken = body<{ accessToken: string }>(memberRegisterRes).accessToken;

--- a/apps/api/test/e2e/api-endpoint/endpoint.e2e.spec.ts
+++ b/apps/api/test/e2e/api-endpoint/endpoint.e2e.spec.ts
@@ -98,7 +98,7 @@ describeIntegration('API Integration Tests', () => {
     it('POST /api/auth/register — creates user and returns tokens', async () => {
       const res = await request(httpServer)
         .post('/api/auth/register')
-        .send({ email: 'admin@koda.test', name: 'Koda Admin', password: 'Admin1234!' })
+        .send({ email: 'admin@koda.test', name: 'Koda Admin', password: 'Admin1234!Aa' })
         .expect(201);
 
       const data = body<{ accessToken: string; refreshToken: string; user: { email: string; role: string } }>(res);
@@ -122,7 +122,7 @@ describeIntegration('API Integration Tests', () => {
     it('POST /api/auth/login — returns tokens (now as ADMIN)', async () => {
       const res = await request(httpServer)
         .post('/api/auth/login')
-        .send({ email: 'admin@koda.test', password: 'Admin1234!' })
+        .send({ email: 'admin@koda.test', password: 'Admin1234!Aa' })
         .expect(200);
 
       const data = body<{ accessToken: string; refreshToken: string }>(res);
@@ -134,7 +134,7 @@ describeIntegration('API Integration Tests', () => {
     it('POST /api/auth/register — creates non-admin user for 403 tests', async () => {
       const res = await request(httpServer)
         .post('/api/auth/register')
-        .send({ email: 'member@koda.test', name: 'Koda Member', password: 'Member1234!' })
+        .send({ email: 'member@koda.test', name: 'Koda Member', password: 'Member1234!Aa' })
         .expect(201);
 
       const data = body<{ accessToken: string; refreshToken: string; user: { email: string; role: string } }>(res);
@@ -142,6 +142,13 @@ describeIntegration('API Integration Tests', () => {
       expect(data.user.role).toBe('MEMBER');
 
       nonAdminUserAccessToken = data.accessToken;
+    });
+
+    it('POST /api/auth/register — 400 for weak password policy violation', async () => {
+      await request(httpServer)
+        .post('/api/auth/register')
+        .send({ email: 'weak@koda.test', name: 'Weak User', password: 'weakpassword123' })
+        .expect(400);
     });
 
     it('POST /api/auth/login — 401 with wrong password', async () => {
@@ -320,6 +327,14 @@ describeIntegration('API Integration Tests', () => {
 
       const data = body<{ description: string }>(res);
       expect(data.description).toBe('Updated description');
+    });
+
+    it('PATCH /api/projects/:slug — 400 for ciWebhookToken shorter than 32 chars', async () => {
+      await request(httpServer)
+        .patch(`/api/projects/${projectSlug}`)
+        .set('Authorization', `Bearer ${userAccessToken}`)
+        .send({ ciWebhookToken: 'short-token' })
+        .expect(400);
     });
   });
 

--- a/apps/api/test/e2e/ast-index.e2e.spec.ts
+++ b/apps/api/test/e2e/ast-index.e2e.spec.ts
@@ -71,7 +71,7 @@ describeE2E('AST/Symbol Index E2E Tests', () => {
     it('should register admin user and get access token', async () => {
       const res = await request(httpServer)
         .post('/api/auth/register')
-        .send({ email: 'admin@koda-ast.test', name: 'AST Admin', password: 'Admin1234!' });
+        .send({ email: 'admin@koda-ast.test', name: 'AST Admin', password: 'Admin1234!Aa' });
 
       expect(res.status).toBe(201);
       const data = body<{ accessToken: string }>(res);
@@ -82,7 +82,7 @@ describeE2E('AST/Symbol Index E2E Tests', () => {
     it('should register agent with DEVELOPER role', async () => {
       const res = await request(httpServer)
         .post('/api/auth/register')
-        .send({ email: 'dev-agent@koda-ast.test', name: 'Dev Agent', password: 'Agent1234!' });
+        .send({ email: 'dev-agent@koda-ast.test', name: 'Dev Agent', password: 'Agent1234!Aa' });
 
       expect(res.status).toBe(201);
 
@@ -278,7 +278,7 @@ describeE2E('AST/Symbol Index E2E Tests', () => {
     it('MEMBER user should receive 403', async () => {
       const memberRes = await request(httpServer)
         .post('/api/auth/register')
-        .send({ email: 'member@koda-ast.test', name: 'Member User', password: 'Member1234!' });
+        .send({ email: 'member@koda-ast.test', name: 'Member User', password: 'Member1234!Aa' });
 
       expect(memberRes.status).toBe(201);
       const memberData = body<{ accessToken: string }>(memberRes);

--- a/apps/api/test/e2e/context.e2e.spec.ts
+++ b/apps/api/test/e2e/context.e2e.spec.ts
@@ -75,7 +75,7 @@ describeIntegration('Context API E2E', () => {
 
     const adminRegisterRes = await request(httpServer)
       .post('/api/auth/register')
-      .send({ email: 'context-admin@koda.test', name: 'Context Admin', password: 'Admin1234!' })
+      .send({ email: 'context-admin@koda.test', name: 'Context Admin', password: 'Admin1234!Aa' })
       .expect(201);
 
     const prisma = app.get<PrismaService<PrismaClient>>(PrismaService);
@@ -88,14 +88,14 @@ describeIntegration('Context API E2E', () => {
 
     const adminLoginRes = await request(httpServer)
       .post('/api/auth/login')
-      .send({ email: 'context-admin@koda.test', password: 'Admin1234!' })
+      .send({ email: 'context-admin@koda.test', password: 'Admin1234!Aa' })
       .expect(200);
 
     adminAccessToken = body<{ accessToken: string }>(adminLoginRes).accessToken;
 
     const memberRegisterRes = await request(httpServer)
       .post('/api/auth/register')
-      .send({ email: 'context-member@koda.test', name: 'Context Member', password: 'Member1234!' })
+      .send({ email: 'context-member@koda.test', name: 'Context Member', password: 'Member1234!Aa' })
       .expect(201);
 
     memberAccessToken = body<{ accessToken: string }>(memberRegisterRes).accessToken;

--- a/apps/api/test/e2e/empty-description.spec.ts
+++ b/apps/api/test/e2e/empty-description.spec.ts
@@ -55,7 +55,7 @@ describeIntegration('US-002: Empty Description Support', () => {
 
     const registerRes = await request(httpServer)
       .post('/api/auth/register')
-      .send({ email: 'test@koda.test', name: 'Test User', password: 'Test1234!' });
+      .send({ email: 'test@koda.test', name: 'Test User', password: 'TestUser1234!' });
 
     userAccessToken = body<{ accessToken: string }>(registerRes).accessToken;
 

--- a/apps/api/test/e2e/hybrid-retriever.e2e.spec.ts
+++ b/apps/api/test/e2e/hybrid-retriever.e2e.spec.ts
@@ -64,46 +64,46 @@ describeIntegration('Hybrid Retriever — KB Search E2E', () => {
 
     const adminRegisterRes = await request(httpServer)
       .post('/api/auth/register')
-      .send({ email: 'hybrid-admin@koda.test', name: 'Hybrid Admin', password: 'Admin1234!' })
+      .send({ email: 'hybrid-admin@koda.test', name: 'Hybrid Admin', password: 'Admin1234!Aa' })
       .expect(201);
     body<{ id: string }>(adminRegisterRes);
 
     const adminLoginRes = await request(httpServer)
       .post('/api/auth/login')
-      .send({ email: 'hybrid-admin@koda.test', password: 'Admin1234!' })
+      .send({ email: 'hybrid-admin@koda.test', password: 'Admin1234!Aa' })
       .expect(200);
     adminAccessToken = body<{ accessToken: string }>(adminLoginRes).accessToken;
 
     const devRegisterRes = await request(httpServer)
       .post('/api/auth/register')
-      .send({ email: 'hybrid-developer@koda.test', name: 'Hybrid Dev', password: 'Dev1234!' })
+      .send({ email: 'hybrid-developer@koda.test', name: 'Hybrid Dev', password: 'DevUser1234!' })
       .expect(201);
     developerAccessToken = body<{ accessToken: string }>(
       await request(httpServer)
         .post('/api/auth/login')
-        .send({ email: 'hybrid-developer@koda.test', password: 'Dev1234!' })
+        .send({ email: 'hybrid-developer@koda.test', password: 'DevUser1234!' })
         .expect(200),
     ).accessToken;
 
     const viewerRegisterRes = await request(httpServer)
       .post('/api/auth/register')
-      .send({ email: 'hybrid-viewer@koda.test', name: 'Hybrid Viewer', password: 'Viewer1234!' })
+      .send({ email: 'hybrid-viewer@koda.test', name: 'Hybrid Viewer', password: 'Viewer1234!Aa' })
       .expect(201);
     viewerAccessToken = body<{ accessToken: string }>(
       await request(httpServer)
         .post('/api/auth/login')
-        .send({ email: 'hybrid-viewer@koda.test', password: 'Viewer1234!' })
+        .send({ email: 'hybrid-viewer@koda.test', password: 'Viewer1234!Aa' })
         .expect(200),
     ).accessToken;
 
     const outsiderRegisterRes = await request(httpServer)
       .post('/api/auth/register')
-      .send({ email: 'hybrid-outsider@koda.test', name: 'Hybrid Outsider', password: 'Outsider1234!' })
+      .send({ email: 'hybrid-outsider@koda.test', name: 'Hybrid Outsider', password: 'Outsider1234!Aa' })
       .expect(201);
     outsiderAccessToken = body<{ accessToken: string }>(
       await request(httpServer)
         .post('/api/auth/login')
-        .send({ email: 'hybrid-outsider@koda.test', password: 'Outsider1234!' })
+        .send({ email: 'hybrid-outsider@koda.test', password: 'Outsider1234!Aa' })
         .expect(200),
     ).accessToken;
 

--- a/scripts/smoke-test-cli.sh
+++ b/scripts/smoke-test-cli.sh
@@ -155,7 +155,7 @@ log "Step 4: Bootstrapping test data..."
 
 REGISTER=$(curl -sf -X POST "$API_URL/api/auth/register" \
   -H "Content-Type: application/json" \
-  -d '{"email":"smoke@koda.test","name":"Smoke Test","password":"Smoke1234!"}' 2>&1)
+  -d '{"email":"smoke@koda.test","name":"Smoke Test","password":"SmokeSecure123!"}' 2>&1)
 if echo "$REGISTER" | grep -q '"accessToken"'; then
   ok "Register user"
 else
@@ -174,7 +174,7 @@ fi
 # Re-login to get a fresh JWT with ADMIN role
 LOGIN=$(curl -sf -X POST "$API_URL/api/auth/login" \
   -H "Content-Type: application/json" \
-  -d '{"email":"smoke@koda.test","password":"Smoke1234!"}' 2>&1)
+  -d '{"email":"smoke@koda.test","password":"SmokeSecure123!"}' 2>&1)
 JWT=$(echo "$LOGIN" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('data',d)['accessToken'])" 2>/dev/null)
 ok "Promoted user to ADMIN"
 


### PR DESCRIPTION
## Summary
- implement S6 by enforcing 32-char minimum secrets for webhook DTOs and related project/VCS secret update fields
- implement S7 by hardening register password policy to 12+ chars with uppercase/lowercase/number/symbol
- implement S8 by reducing JWT defaults to 15m access and 7d refresh tokens
- align auth defaults across module, config, env validation, and env templates
- update password fixtures in API tests to satisfy the stronger policy
- add regression specs for register DTO, webhook DTO, auth config defaults, project DTO, and VCS DTO secret validation
- add API e2e negative-path checks for weak register password and short ciWebhookToken
- localize new validation messages in en/zh dictionaries

## Code Review Findings
- resolved zh localization regression for newly introduced validation messages
- added API boundary validation tests requested by review for hardening constraints
- no remaining critical/high findings in final review

## Validation
- cd apps/api && bun run test
- cd apps/api && bun run lint
- cd apps/api && bun run type-check
- cd apps/api && bun x jest --runTestsByPath test/e2e/api-endpoint/endpoint.e2e.spec.ts

## Notes
- short existing webhook-like secrets will now fail validation on update/create paths and should be rotated to 32+ chars