### PR TITLE
fix(api): resolve M1-M9 memory leak findings

### DIFF
--- a/apps/api/src/outbox/outbox-fan-out-registry.spec.ts
+++ b/apps/api/src/outbox/outbox-fan-out-registry.spec.ts
@@ -66,6 +66,26 @@ describe('OutboxFanOutRegistry', () => {
 
       expect(handlers).toHaveLength(2);
     });
+
+    it('does not register duplicate handler references for the same eventType', () => {
+      const handler = jest.fn();
+      registry.register('foo', handler);
+      registry.register('foo', handler);
+
+      const handlers = registry.getHandlers('foo');
+
+      expect(handlers).toHaveLength(1);
+      expect(handlers[0]).toBe(handler);
+    });
+
+    it('unregister removes handler and deletes key when no handlers remain', () => {
+      const handler = jest.fn();
+      registry.register('foo', handler);
+
+      registry.unregister('foo', handler);
+
+      expect(registry.getHandlers('foo')).toHaveLength(0);
+    });
   });
 
   describe('AC41: DEFAULT_HANDLERS registration', () => {

--- a/apps/api/src/outbox/outbox-fan-out-registry.ts
+++ b/apps/api/src/outbox/outbox-fan-out-registry.ts
@@ -198,8 +198,19 @@ export class OutboxFanOutRegistry implements OnModuleInit {
 
   register(eventType: string, handler: (payload: unknown) => void | Promise<void>): void {
     const existing = this.handlers.get(eventType) || [];
-    existing.push(handler);
-    this.handlers.set(eventType, existing);
+    if (!existing.includes(handler)) {
+      this.handlers.set(eventType, [...existing, handler]);
+    }
+  }
+
+  unregister(eventType: string, handler: (payload: unknown) => void | Promise<void>): void {
+    const existing = this.handlers.get(eventType) || [];
+    const filtered = existing.filter((h) => h !== handler);
+    if (filtered.length > 0) {
+      this.handlers.set(eventType, filtered);
+    } else {
+      this.handlers.delete(eventType);
+    }
   }
 
   async dispatch(input: { eventType: string; payload: unknown }): Promise<void> {

--- a/apps/api/src/projects/projects.service.ts
+++ b/apps/api/src/projects/projects.service.ts
@@ -201,13 +201,16 @@ export class ProjectsService {
     }
 
     // Soft delete by setting deletedAt
-    return ProjectResponseDto.from(
-      await this.db.project.update({
-        where: { slug },
-        data: {
-          deletedAt: new Date(),
-        },
-      })
-    );
+    const deletedProject = await this.db.project.update({
+      where: { slug },
+      data: {
+        deletedAt: new Date(),
+      },
+    });
+
+    this.ragService.clearProjectCaches(deletedProject.id);
+    this.hybridRetrieverService?.invalidateGraphifyEnabledCache(deletedProject.id);
+
+    return ProjectResponseDto.from(deletedProject);
   }
 }

--- a/apps/api/src/rag/hybrid-retriever.service.ts
+++ b/apps/api/src/rag/hybrid-retriever.service.ts
@@ -486,6 +486,9 @@ export class HybridRetrieverService implements OnModuleInit, OnModuleDestroy {
     if (cached && cached.expiresAt > Date.now()) {
       return cached.value;
     }
+    if (cached) {
+      this.graphifyEnabledCache.delete(cacheKey);
+    }
 
     const project = await this.prisma.client.project.findUnique({
       where: { id: projectId },

--- a/apps/api/src/rag/lexical-index.ts
+++ b/apps/api/src/rag/lexical-index.ts
@@ -37,8 +37,10 @@ interface ProjectIndex {
 export class LexicalIndex {
   readonly k1 = 1.5;
   readonly b = 0.75;
+  private readonly maxIndexes = 1_000;
 
   private indexes = new Map<string, ProjectIndex>();
+  private lastAccessed = new Map<string, number>();
 
   buildIndex(projectId: string, docs: Bm25Document[]): void {
     const projectIndex = this.getOrCreateProjectIndex(projectId);
@@ -67,6 +69,7 @@ export class LexicalIndex {
     if (!projectIndex || projectIndex.docs.size === 0) {
       return [];
     }
+    this.touchProject(projectId);
 
     if (!projectIndex.warmupCompleted && projectIndex.docs.size > 0) {
       if (projectIndex.rebuildLock) {
@@ -139,6 +142,7 @@ export class LexicalIndex {
   removeDocument(projectId: string, docId: string): void {
     const projectIndex = this.indexes.get(projectId);
     if (!projectIndex) return;
+    this.touchProject(projectId);
 
     const doc = projectIndex.docs.get(docId);
     if (!doc) return;
@@ -159,7 +163,7 @@ export class LexicalIndex {
       const docLengths = Array.from(projectIndex.docs.values()).map(d => d.docLength);
       projectIndex.avgDocLength = docLengths.reduce((a, b) => a + b, 0) / docLengths.length;
     } else {
-      projectIndex.avgDocLength = 0;
+      this.clearProject(projectId);
     }
   }
 
@@ -170,6 +174,7 @@ export class LexicalIndex {
   setWarmupCompleted(projectId: string, completed: boolean): void {
     const projectIndex = this.indexes.get(projectId);
     if (projectIndex) {
+      this.touchProject(projectId);
       projectIndex.warmupCompleted = completed;
     }
   }
@@ -206,6 +211,7 @@ export class LexicalIndex {
       if (!projectIndex || projectIndex.docs.size === 0) {
         return false;
       }
+      this.touchProject(payload.projectId);
 
       while (projectIndex.rebuildLock) {
         await new Promise(resolve => setImmediate(resolve));
@@ -234,9 +240,16 @@ export class LexicalIndex {
     return false;
   }
 
+  clearProject(projectId: string): void {
+    this.indexes.delete(projectId);
+    this.lastAccessed.delete(projectId);
+  }
+
   private getOrCreateProjectIndex(projectId: string): ProjectIndex {
+    this.touchProject(projectId);
     let projectIndex = this.indexes.get(projectId);
     if (!projectIndex) {
+      this.evictIfNeeded();
       projectIndex = {
         docs: new Map(),
         termDocFreq: new Map(),
@@ -247,6 +260,27 @@ export class LexicalIndex {
       this.indexes.set(projectId, projectIndex);
     }
     return projectIndex;
+  }
+
+  private touchProject(projectId: string): void {
+    this.lastAccessed.set(projectId, Date.now());
+  }
+
+  private evictIfNeeded(): void {
+    while (this.indexes.size >= this.maxIndexes) {
+      let oldestProjectId: string | null = null;
+      let oldestTs = Number.POSITIVE_INFINITY;
+      for (const [projectId, ts] of this.lastAccessed) {
+        if (ts < oldestTs) {
+          oldestTs = ts;
+          oldestProjectId = projectId;
+        }
+      }
+      if (!oldestProjectId) {
+        break;
+      }
+      this.clearProject(oldestProjectId);
+    }
   }
 
   private indexDocument(doc: Bm25Document): IndexedDocument {

--- a/apps/api/src/rag/rag.service.ts
+++ b/apps/api/src/rag/rag.service.ts
@@ -8,6 +8,7 @@ import { ITransactionManager, TRANSACTION_MANAGER } from '@nathapp/nestjs-data';
 import { EmbeddingService } from './embedding.service';
 import { FTS_OPTIMIZE_STRATEGY, FtsOptimizeStrategy } from './strategies/fts-optimize-strategy.interface';
 import { LexicalIndex } from './lexical-index';
+import { EntityStore } from './entity-store';
 import { GraphStoreService } from './graph-store.service';
 import { IncrementalGraphDiffService } from './incremental-graph-diff.service';
 import type { GraphifyNodeDto, GraphifyLinkDto } from './dto/import-graphify.dto';
@@ -158,6 +159,7 @@ export class RagService implements OnModuleInit, OnModuleDestroy {
     @Optional() @Inject(FTS_OPTIMIZE_STRATEGY) private readonly optimizeStrategy?: FtsOptimizeStrategy,
     @Optional() private readonly prisma?: PrismaService<PrismaClient>,
     @Optional() private readonly lexicalIndex?: LexicalIndex,
+    @Optional() private readonly entityStore?: EntityStore,
     @Optional() @Inject(TRANSACTION_MANAGER) private readonly txManager?: ITransactionManager,
     @Optional() private readonly graphStore?: GraphStoreService,
     @Optional() @Inject(forwardRef(() => IncrementalGraphDiffService)) private readonly incrementalDiff?: IncrementalGraphDiffService,
@@ -207,6 +209,14 @@ export class RagService implements OnModuleInit, OnModuleDestroy {
     }
 
     this.db = null;
+  }
+
+  clearProjectCaches(projectId: string): void {
+    this.tableCache.delete(`project_${projectId}`);
+    this.firstAccessedProjectIds.delete(projectId);
+    this.lexicalIndex?.clearProject(projectId);
+    this.entityStore?.clear(projectId);
+    this.optimizeStrategy?.clearProject?.(projectId);
   }
 
   /**

--- a/apps/api/src/rag/strategies/counter-optimize.strategy.spec.ts
+++ b/apps/api/src/rag/strategies/counter-optimize.strategy.spec.ts
@@ -119,4 +119,32 @@ describe('CounterOptimizeStrategy', () => {
       expect(t2.optimize).not.toHaveBeenCalled();
     });
   });
+
+  describe('cleanup', () => {
+    it('clearProject removes project counter state', async () => {
+      const strategy = new CounterOptimizeStrategy(
+        mockConfigService({ 'rag.ftsOptimizeThreshold': 2 }),
+      );
+      const table = mockTable();
+      await strategy.onInsert('p1', table); // p1 count: 1
+      strategy.clearProject('p1');
+      await strategy.onInsert('p1', table); // count should restart at 1
+      expect(table.optimize).not.toHaveBeenCalled();
+    });
+
+    it('onDestroy clears all counters', async () => {
+      const strategy = new CounterOptimizeStrategy(
+        mockConfigService({ 'rag.ftsOptimizeThreshold': 2 }),
+      );
+      const t1 = mockTable();
+      const t2 = mockTable();
+      await strategy.onInsert('p1', t1);
+      await strategy.onInsert('p2', t2);
+      await strategy.onDestroy();
+      await strategy.onInsert('p1', t1);
+      await strategy.onInsert('p2', t2);
+      expect(t1.optimize).not.toHaveBeenCalled();
+      expect(t2.optimize).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/apps/api/src/rag/strategies/counter-optimize.strategy.ts
+++ b/apps/api/src/rag/strategies/counter-optimize.strategy.ts
@@ -34,7 +34,11 @@ export class CounterOptimizeStrategy implements FtsOptimizeStrategy {
     void table.optimize();
   }
 
+  clearProject(projectId: string): void {
+    this.counters.delete(projectId);
+  }
+
   async onDestroy(): Promise<void> {
-    // no-op
+    this.counters.clear();
   }
 }

--- a/apps/api/src/rag/strategies/cron-optimize.strategy.ts
+++ b/apps/api/src/rag/strategies/cron-optimize.strategy.ts
@@ -8,6 +8,7 @@ type LanceTable = any;
 /** Minimal interface for SchedulerRegistry — full type added when @nestjs/schedule is installed (US-002) */
 interface SchedulerRegistryLike {
   addInterval(name: string, interval: ReturnType<typeof setInterval>): void;
+  deleteInterval(name: string): void;
 }
 
 @Injectable()
@@ -15,6 +16,7 @@ export class CronOptimizeStrategy implements FtsOptimizeStrategy {
   private readonly logger = new Logger(CronOptimizeStrategy.name);
   private readonly dirtyTables = new Map<string, LanceTable>();
   private readonly intervalMs: number;
+  private intervalId: ReturnType<typeof setInterval> | null = null;
 
   constructor(
     private readonly configService: ConfigService,
@@ -22,10 +24,10 @@ export class CronOptimizeStrategy implements FtsOptimizeStrategy {
     private readonly schedulerRegistry: SchedulerRegistryLike,
   ) {
     this.intervalMs = this.configService.get<number>('rag.ftsOptimizeIntervalMs') ?? 300_000;
-    const interval = setInterval(() => {
+    this.intervalId = setInterval(() => {
       void this.optimizeDirtyTables();
     }, this.intervalMs);
-    this.schedulerRegistry.addInterval('fts-optimize', interval);
+    this.schedulerRegistry.addInterval('fts-optimize', this.intervalId);
   }
 
   onInsert(projectId: string, table: LanceTable): Promise<void> {
@@ -53,6 +55,15 @@ export class CronOptimizeStrategy implements FtsOptimizeStrategy {
   }
 
   async onDestroy(): Promise<void> {
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+    }
+    try {
+      this.schedulerRegistry.deleteInterval('fts-optimize');
+    } catch {
+      // Interval may already be gone; ignore.
+    }
     await this.optimizeDirtyTables();
   }
 }

--- a/apps/api/src/rag/strategies/fts-optimize-strategy.interface.ts
+++ b/apps/api/src/rag/strategies/fts-optimize-strategy.interface.ts
@@ -7,4 +7,5 @@ export interface FtsOptimizeStrategy {
   onInsert(projectId: string, table: LanceTable): Promise<void>;
   onFirstAccess(projectId: string, table: LanceTable): void;
   onDestroy(): Promise<void>;
+  clearProject?(projectId: string): void;
 }

--- a/apps/api/src/vcs/vcs-polling.service.ts
+++ b/apps/api/src/vcs/vcs-polling.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, OnModuleInit, Logger } from '@nestjs/common';
+import { Injectable, OnModuleDestroy, OnModuleInit, Logger } from '@nestjs/common';
 import { SchedulerRegistry } from '@nestjs/schedule';
 import { PrismaService } from '@nathapp/nestjs-prisma';
 import { VcsConnection, Project } from '@prisma/client';
@@ -28,8 +28,9 @@ interface ExtendedPrismaClient {
  * Polling service for syncing issues on a schedule
  */
 @Injectable()
-export class VcsPollingService implements OnModuleInit {
+export class VcsPollingService implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(VcsPollingService.name);
+  private readonly scheduledConnectionIds = new Set<string>();
 
   constructor(
     private readonly prisma: PrismaService,
@@ -45,6 +46,12 @@ export class VcsPollingService implements OnModuleInit {
   async onModuleInit() {
     // Initialize polling for all active connections with polling mode
     await this.initializePolling();
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    for (const connectionId of this.scheduledConnectionIds) {
+      this.unschedulePolling(connectionId);
+    }
   }
 
   /**
@@ -90,6 +97,7 @@ export class VcsPollingService implements OnModuleInit {
     }, connection.pollingIntervalMs);
 
     this.schedulerRegistry.addInterval(scheduleName, interval);
+    this.scheduledConnectionIds.add(connection.id);
     this.logger.debug(`Scheduled polling for connection ${connection.id} every ${connection.pollingIntervalMs}ms`);
   }
 
@@ -100,6 +108,7 @@ export class VcsPollingService implements OnModuleInit {
     } catch {
       // Nothing to remove.
     }
+    this.scheduledConnectionIds.delete(connectionId);
   }
 
   async refreshConnectionSchedule(connectionId: string): Promise<void> {

--- a/apps/api/src/vcs/vcs-webhook.service.ts
+++ b/apps/api/src/vcs/vcs-webhook.service.ts
@@ -1,4 +1,4 @@
-import { HttpException, HttpStatus, Injectable, Logger, Optional } from '@nestjs/common';
+import { HttpException, HttpStatus, Injectable, Logger, OnModuleDestroy, Optional } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { createHmac, timingSafeEqual } from 'crypto';
 import { PrismaService } from '@nathapp/nestjs-prisma';
@@ -105,9 +105,11 @@ interface TicketLinkData {
 }
 
 @Injectable()
-export class VcsWebhookService {
+export class VcsWebhookService implements OnModuleDestroy {
   private readonly logger = new Logger(VcsWebhookService.name);
   private readonly recentCommitHashes = new Map<string, number>();
+  private readonly dedupWindowMs = 5 * 60 * 1000;
+  private readonly cleanupInterval: ReturnType<typeof setInterval>;
   private dbDedupVerified = false;
   private dbDedupWorks = false;
 
@@ -118,12 +120,29 @@ export class VcsWebhookService {
     @Optional() private readonly vcsLinkExtractorService?: VcsLinkExtractorService,
     @Optional() private readonly configService?: ConfigService,
     @Optional() private readonly outboxService?: OutboxService,
-  ) {}
+  ) {
+    this.cleanupInterval = setInterval(() => {
+      this.cleanupStaleEntries();
+    }, this.dedupWindowMs);
+  }
 
   // PrismaClientLike from @nathapp/nestjs-prisma doesn't expose VCS models,
   // but they exist at runtime. Using double cast to allow property access.
   private get db() {
     return this.prisma.client as unknown as ExtendedPrismaClient;
+  }
+
+  onModuleDestroy(): void {
+    clearInterval(this.cleanupInterval);
+    this.recentCommitHashes.clear();
+  }
+
+  private cleanupStaleEntries(now = Date.now()): void {
+    for (const [key, timestamp] of this.recentCommitHashes) {
+      if (now - timestamp > this.dedupWindowMs) {
+        this.recentCommitHashes.delete(key);
+      }
+    }
   }
 
   /**
@@ -616,14 +635,9 @@ export class VcsWebhookService {
     }
 
     const now = Date.now();
-    const dedupWindowMs = 5 * 60 * 1000;
 
-    // Evict stale entries older than the dedup window
-    for (const [key, timestamp] of this.recentCommitHashes) {
-      if (now - timestamp > dedupWindowMs) {
-        this.recentCommitHashes.delete(key);
-      }
-    }
+    // Evict stale entries older than the dedup window.
+    this.cleanupStaleEntries(now);
 
     // DB-backed dedup check (authoritative, works across instances)
     const rawClient = this.prisma.client as unknown as Record<string, unknown>;
@@ -647,7 +661,7 @@ export class VcsWebhookService {
               eventType: 'code_commit',
               eventId: commitHash,
               status: { in: ['pending', 'processing'] },
-              createdAt: { gte: new Date(now - dedupWindowMs) },
+              createdAt: { gte: new Date(now - this.dedupWindowMs) },
             },
             select: { id: true },
             take: 1,
@@ -664,7 +678,7 @@ export class VcsWebhookService {
 
       // Fast-path: in-memory dedup within this instance (fallback when DB dedup is unavailable or unverified)
       const lastEnqueuedTime = this.recentCommitHashes.get(recentKey);
-      if ((!outboxDelegate || (this.dbDedupVerified && !this.dbDedupWorks)) && lastEnqueuedTime && (now - lastEnqueuedTime) < dedupWindowMs) {
+      if ((!outboxDelegate || (this.dbDedupVerified && !this.dbDedupWorks)) && lastEnqueuedTime && (now - lastEnqueuedTime) < this.dedupWindowMs) {
         this.logger.debug(`Skipping duplicate commit ${commitHash} within deduplication window`);
         continue;
       }
@@ -705,7 +719,7 @@ export class VcsWebhookService {
                 eventType: 'code_commit',
                 eventId: commitHash,
                 status: { in: ['pending', 'processing'] },
-                createdAt: { gte: new Date(now - dedupWindowMs) },
+                createdAt: { gte: new Date(now - this.dedupWindowMs) },
               },
               select: { id: true },
               take: 1,


### PR DESCRIPTION
## Summary
- Fix M1: add OnModuleDestroy cleanup in VcsPollingService and unschedule active polling intervals safely.
- Fix M2: clear and deregister cron optimize interval in CronOptimizeStrategy during teardown.
- Fix M4: add periodic stale-entry cleanup and module-destroy teardown in VcsWebhookService for recentCommitHashes.
- Fix M5: prune stale graphifyEnabledCache entries on TTL miss in HybridRetrieverService.
- Fix M6: add handler deduplication and unregister() support in OutboxFanOutRegistry.
- Fix M7: add per-project LRU-style eviction and explicit project cleanup in LexicalIndex.
- Fix M8: clear project-scoped RAG/entity caches on project soft-delete via RagService.clearProjectCaches() call from ProjectsService.
- Fix M9: add per-project and full-map cleanup in CounterOptimizeStrategy and expose optional clearProject() hook in optimize strategy interface.

## Validation
- bun run lint (repo root) passed
- bun run type-check (repo root) passed
- bun run test (repo root) passed
  - @nathapp/koda-web: 71/71 suites passed
  - @nathapp/koda-cli: 24/24 suites passed
  - @nathapp/koda-api: 89/89 suites passed
