### PR TITLE
chore(api): data-layering rules + tx-manager mock & leaked-timer test fixes

### DIFF
--- a/.nax/rules/api-data.md
+++ b/.nax/rules/api-data.md
@@ -21,6 +21,53 @@ priority: 80
 - Ticket refs use `PROJECT_KEY-NUMBER` format
 - Keep workflow constraints centralized in state-machine validation
 
+## Layering & Boundaries (repository → service → public)
+
+Data flows **repository → service → public**, and each layer only talks to the one directly below it:
+
+- **Repository** — module-internal. Owns all Prisma access and all Prisma-to-domain mapping. Returns domain types, never raw Prisma models. Lives behind a `*_REPOSITORY` token used only inside its own module.
+- **Service** — the module's public face. Orchestrates repositories, applies business rules, returns domain types or DTOs. The only provider a module exports.
+- **Public (controllers + other modules)** — depend on services only.
+
+### `@prisma/client` is confined to the repository layer
+- Import Prisma model/client types (`PrismaClient`, `Project`, `Ticket`, …) **only** in `*.repository.ts` and persistence-mapping / domain files
+- **Banned** in controllers, DTOs, service *public* method signatures, and any other module
+- A controller that imports from `@prisma/client` is always a violation — route the data through a service that returns a DTO/domain type
+
+```typescript
+// Banned: controller leaking a Prisma model to the HTTP boundary
+import { Project } from '@prisma/client';
+@Get() list(): Promise<Project[]> { /* ... */ }
+
+// Correct: controller depends on a service that returns a DTO/domain type
+@Get() async list(): Promise<JsonResponse<ProjectDto[]>> {
+  return JsonResponse.Ok(await this.projects.list());
+}
+```
+
+### Repositories are module-private — never exported
+- A repository class or its `*_REPOSITORY` token MUST NOT appear in a module's `exports:`. Neither must `PrismaService`
+- Export **services** only — that is the module's entire public contract
+- `memory.module.ts` is the reference: `MEMORY_ITEM_REPOSITORY` is defined and consumed only inside the module and never exported
+
+```typescript
+// Banned: vcs.module.ts leaks a repository token to other modules
+exports: [VCS_REPOSITORY, VcsConnectionService, /* ... */]
+// Correct: export services only
+exports: [VcsConnectionService, VcsSyncService, /* ... */]
+```
+
+### Controllers and cross-module callers use services, not repositories
+- Never inject a repository or `PrismaService` into a controller
+- A module that needs another module's data calls that module's **service**, never its repository or Prisma directly
+- Service public methods return domain types or DTOs — never Prisma model types or `PrismaClient`
+
+### Migration carve-out (legacy direct-Prisma code)
+- Much existing code (auth, RAG, events, tickets/projects/labels services, webhooks, monitoring, …) injects `PrismaService` directly because it predates the repository pattern. This is **tolerated legacy**, not a template
+- **New** services and modules MUST follow repository → service → public
+- When you touch a legacy file for substantive work, prefer extracting a repository over extending the direct-Prisma usage
+- Even in legacy modules, do **not** add `@prisma/client` imports to controllers
+
 ## Prisma Module Setup
 - `PrismaModule.forRoot` MUST include `transaction: true` — this activates `TRANSACTION_MANAGER` and the transparent proxy on `PrismaService.client`
 - Without `transaction: true`, `@Inject(TRANSACTION_MANAGER)` will throw at startup
@@ -113,10 +160,10 @@ async findByTicketId(ticketId: string): Promise<CommentDomain[]> {
 }
 ```
 
-## PrismaService — Direct Injection (Non-Repository Code)
-- Inject `PrismaService` (without generic) for non-repository code (auth, RAG, VCS webhook, outbox) unless the file is already migrated to a repository
-- Access the client via `this.prisma.client` — never cast to `PrismaClient` or a custom interface
-- Do NOT write `private get db() { return this.prisma.client as unknown as T; }` — this defeats the transparent proxy
+## PrismaService — Direct Injection (legacy carve-out only)
+- Direct `PrismaService` injection outside a repository is **legacy** — see the migration carve-out under [Layering & Boundaries](#layering--boundaries-repository--service--public). Do not introduce it in new services or modules
+- Where it already exists: access the client via `this.prisma.client` — never cast to `PrismaClient` or a custom interface
+- Do NOT write `private get db() { return this.prisma.client as unknown as T; }` — this defeats the transparent proxy and re-leaks Prisma types
 
 ## Unsafe Casts — Banned
 - Do not cast `this.prisma.client as unknown as PrismaClient`

--- a/apps/api/src/memory/memory-item-repository.spec.ts
+++ b/apps/api/src/memory/memory-item-repository.spec.ts
@@ -18,7 +18,11 @@ describe('PrismaMemoryItemRepository.findByProjectMemory', () => {
     client: mockPrismaClient,
   };
 
-  const mockTransactionManager = {};
+  const mockTransactionManager = {
+    run: jest.fn((fn: () => Promise<unknown>) => fn()),
+    getClient: jest.fn(),
+    isInTransaction: jest.fn(() => false),
+  };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({

--- a/apps/api/test/integration/agent-permissions/labels-agent-permissions.integration.spec.ts
+++ b/apps/api/test/integration/agent-permissions/labels-agent-permissions.integration.spec.ts
@@ -46,7 +46,14 @@ describe('LabelsService — agent permissions', () => {
       providers: [
         LabelsService,
         { provide: PrismaService, useValue: mockPrisma },
-        { provide: TRANSACTION_MANAGER, useValue: { transaction: jest.fn() } },
+        {
+          provide: TRANSACTION_MANAGER,
+          useValue: {
+            run: jest.fn((fn: () => Promise<unknown>) => fn()),
+            getClient: jest.fn(),
+            isInTransaction: jest.fn(() => false),
+          },
+        },
       ],
     }).compile();
 

--- a/apps/api/test/integration/agent-permissions/tickets-agent-permissions.integration.spec.ts
+++ b/apps/api/test/integration/agent-permissions/tickets-agent-permissions.integration.spec.ts
@@ -69,7 +69,14 @@ describe('TicketsService — agent permissions', () => {
       providers: [
         TicketsService,
         { provide: PrismaService, useValue: mockPrisma },
-        { provide: TRANSACTION_MANAGER, useValue: { transaction: jest.fn() } },
+        {
+          provide: TRANSACTION_MANAGER,
+          useValue: {
+            run: jest.fn((fn: () => Promise<unknown>) => fn()),
+            getClient: jest.fn(),
+            isInTransaction: jest.fn(() => false),
+          },
+        },
       ],
     }).compile();
 

--- a/apps/api/test/integration/memory/outbox-fanout-extraction.integration.spec.ts
+++ b/apps/api/test/integration/memory/outbox-fanout-extraction.integration.spec.ts
@@ -35,7 +35,14 @@ describe('AC8: OutboxFanOutRegistry dispatches to ExtractionService', () => {
         ExtractionService,
         PrismaMemoryItemRepository,
         { provide: PrismaService, useValue: mockPrismaService },
-        { provide: TRANSACTION_MANAGER, useValue: { transaction: jest.fn() } },
+        {
+          provide: TRANSACTION_MANAGER,
+          useValue: {
+            run: jest.fn((fn: () => Promise<unknown>) => fn()),
+            getClient: jest.fn(),
+            isInTransaction: jest.fn(() => false),
+          },
+        },
       ],
     }).compile();
 

--- a/apps/api/test/integration/tickets/tickets-status-update.integration.spec.ts
+++ b/apps/api/test/integration/tickets/tickets-status-update.integration.spec.ts
@@ -73,7 +73,14 @@ describe('US-003: TicketsService.update() — status field', () => {
       providers: [
         TicketsService,
         { provide: PrismaService, useValue: mockPrismaService },
-        { provide: TRANSACTION_MANAGER, useValue: { transaction: jest.fn() } },
+        {
+          provide: TRANSACTION_MANAGER,
+          useValue: {
+            run: jest.fn((fn: () => Promise<unknown>) => fn()),
+            getClient: jest.fn(),
+            isInTransaction: jest.fn(() => false),
+          },
+        },
       ],
     }).compile();
 

--- a/apps/api/test/integration/vcs/vcs-polling-comprehensive.spec.ts
+++ b/apps/api/test/integration/vcs/vcs-polling-comprehensive.spec.ts
@@ -135,6 +135,11 @@ describe('VcsPollingService - Comprehensive Behavior Tests', () => {
     vcsSyncLog: { ...mockVcsSyncLogDelegate },
   } as any;
 
+  // schedulePolling() creates real Node setInterval timers. The mocked
+  // SchedulerRegistry never clears them (unlike the real one), so we track and
+  // clear them in afterEach to stop leaked timers from firing poll() across tests.
+  const createdIntervals: NodeJS.Timeout[] = [];
+
   beforeEach(async () => {
     jest.clearAllMocks();
     jest.restoreAllMocks();
@@ -168,7 +173,9 @@ describe('VcsPollingService - Comprehensive Behavior Tests', () => {
         {
           provide: SchedulerRegistry,
           useValue: {
-            addInterval: jest.fn(),
+            addInterval: jest.fn((_name: string, interval: NodeJS.Timeout) => {
+              createdIntervals.push(interval);
+            }),
             deleteInterval: jest.fn(),
             getInterval: jest.fn(),
             getIntervals: jest.fn(() => []),
@@ -184,6 +191,11 @@ describe('VcsPollingService - Comprehensive Behavior Tests', () => {
   });
 
   afterEach(async () => {
+    // Clear any real interval timers schedulePolling() created so they don't
+    // fire poll() during later tests (the mocked registry can't clear them).
+    while (createdIntervals.length > 0) {
+      clearInterval(createdIntervals.pop());
+    }
     await module.close();
   });
 

--- a/apps/api/test/integration/vcs/vcs-polling-pr-sync.integration.spec.ts
+++ b/apps/api/test/integration/vcs/vcs-polling-pr-sync.integration.spec.ts
@@ -83,6 +83,11 @@ describe('VcsPollingService PR Sync Integration (VCS-P3-002-C AC1)', () => {
     vcsSyncLog: { ...mockVcsSyncLogDelegate },
   } as any;
 
+  // schedulePolling() creates real Node setInterval timers. The mocked
+  // SchedulerRegistry never clears them (unlike the real one), so we track and
+  // clear them in afterEach to stop leaked timers from firing poll() across tests.
+  const createdIntervals: NodeJS.Timeout[] = [];
+
   beforeEach(async () => {
     jest.clearAllMocks();
     jest.restoreAllMocks();
@@ -111,7 +116,9 @@ describe('VcsPollingService PR Sync Integration (VCS-P3-002-C AC1)', () => {
         {
           provide: SchedulerRegistry,
           useValue: {
-            addInterval: jest.fn(),
+            addInterval: jest.fn((_name: string, interval: NodeJS.Timeout) => {
+              createdIntervals.push(interval);
+            }),
             deleteInterval: jest.fn(),
             getIntervals: jest.fn(() => []),
           },
@@ -124,6 +131,12 @@ describe('VcsPollingService PR Sync Integration (VCS-P3-002-C AC1)', () => {
   });
 
   afterEach(async () => {
+    // Clear any real interval timers schedulePolling() created so they don't
+    // fire poll() during later tests (the mocked registry can't clear them).
+    while (createdIntervals.length > 0) {
+      clearInterval(createdIntervals.pop());
+    }
+    delete process.env.VCS_ENCRYPTION_KEY;
     await module.close();
   });
 

--- a/apps/api/test/integration/vcs/vcs-polling.service.spec.ts
+++ b/apps/api/test/integration/vcs/vcs-polling.service.spec.ts
@@ -122,6 +122,11 @@ describe('VcsPollingService', () => {
     vcsSyncLog: { ...mockVcsSyncLogDelegate },
   } as any;
 
+  // schedulePolling() creates real Node setInterval timers. The mocked
+  // SchedulerRegistry never clears them (unlike the real one), so we track and
+  // clear them in afterEach to stop leaked timers from firing poll() across tests.
+  const createdIntervals: NodeJS.Timeout[] = [];
+
   beforeEach(async () => {
     jest.clearAllMocks();
     jest.restoreAllMocks();
@@ -155,7 +160,9 @@ describe('VcsPollingService', () => {
         {
           provide: SchedulerRegistry,
           useValue: {
-            addInterval: jest.fn(),
+            addInterval: jest.fn((_name: string, interval: NodeJS.Timeout) => {
+              createdIntervals.push(interval);
+            }),
             deleteInterval: jest.fn(),
             getInterval: jest.fn(),
             getIntervals: jest.fn(() => []),
@@ -171,6 +178,11 @@ describe('VcsPollingService', () => {
   });
 
   afterEach(async () => {
+    // Clear any real interval timers schedulePolling() created so they don't
+    // fire poll() during later tests (the mocked registry can't clear them).
+    while (createdIntervals.length > 0) {
+      clearInterval(createdIntervals.pop());
+    }
     await module.close();
   });
 


### PR DESCRIPTION
## Summary

Three related changes that came out of a `@nathapp/nestjs-*` upgrade review of `TRANSACTION_MANAGER` usage.

### 1. Data-layering rules (`.nax/rules/api-data.md`)
Prisma was leaking past the data layer (controllers importing `@prisma/client`, repository tokens exported from modules). Added a **Layering & Boundaries (repository → service → public)** section:
- Repositories are module-internal — never in a module's `exports:`.
- `@prisma/client` types stay in the repository layer; banned in controllers, DTOs, service public signatures, and other modules.
- Controllers depend on services that return DTOs/domain types.
- Existing direct-`PrismaService` code is captured as a **legacy migration carve-out** (strict for new code, no immediate churn). The old "PrismaService direct injection" rule is reframed as legacy-only.

### 2. `TRANSACTION_MANAGER` mock compliance (test-only)
Replaced stale `{ transaction: jest.fn() }` / empty `{}` mocks — which never matched `ITransactionManager` — with the correct `{ run, getClient, isInTransaction }` shape across 5 specs.

### 3. Leaked polling-timer fix (test-only)
`VcsPollingService.schedulePolling()` creates real `setInterval` timers; the mocked `SchedulerRegistry` never clears them, so they leaked across tests and fired `poll()` — surfacing as a nondeterministic `"VCS encryption key not configured"` failure in an unrelated assertion. The 3 vcs-polling specs now track created intervals and `clearInterval` them in `afterEach`.

## Test plan
- [ ] `bun run test` (unit) green
- [ ] `bun run test:integration` green — confirm the previously-flaky `vcs-polling-comprehensive` failure no longer reproduces
- [ ] `nax rules lint` passes (verified locally)

> Note: related guidance was also added to the `nathapp-nestjs-patterns` skill (outside this repo).