### PR TITLE
feat(cli): add webhook, context, memory, and code-intel commands

### DIFF
--- a/apps/cli/src/commands/code-intel.spec.ts
+++ b/apps/cli/src/commands/code-intel.spec.ts
@@ -1,0 +1,135 @@
+jest.mock('chalk', () => ({
+  cyan: { bold: (s: string) => s },
+  gray: (s: string) => s,
+  green: (s: string) => s,
+  red: (s: string) => s,
+  yellow: (s: string) => s,
+}));
+
+const mockData: Record<string, string> = {};
+const mockStore = {
+  get: jest.fn((key: string) => mockData[key] || ''),
+  set: jest.fn((key: string, value: string) => { mockData[key] = value; }),
+};
+jest.mock('conf', () => jest.fn(() => mockStore));
+
+jest.mock('../generated', () => ({
+  codeIntelControllerGetSymbol: jest.fn(),
+  codeIntelControllerGetCallers: jest.fn(),
+  codeIntelControllerGetCallees: jest.fn(),
+  OpenAPI: { BASE: '', TOKEN: '' },
+}));
+jest.mock('../generated/core/OpenAPI', () => ({ OpenAPI: { BASE: '', TOKEN: '' } }));
+
+jest.mock('../config', () => ({
+  resolveContext: jest.fn(),
+}));
+
+import { Command } from 'commander';
+import { codeIntelCommand } from './code-intel';
+import {
+  codeIntelControllerGetSymbol,
+  codeIntelControllerGetCallers,
+  codeIntelControllerGetCallees,
+} from '../generated';
+import { resolveContext } from '../config';
+
+const mockResolveContext = resolveContext as jest.Mock;
+const mockGetSymbol = codeIntelControllerGetSymbol as jest.Mock;
+const mockGetCallers = codeIntelControllerGetCallers as jest.Mock;
+const mockGetCallees = codeIntelControllerGetCallees as jest.Mock;
+
+const CTX = { apiKey: 'sk-test', apiUrl: 'http://localhost:3100/api', projectSlug: 'my-proj' };
+const SYMBOL_ID = 'repo-1:src/auth.ts::AuthService';
+
+describe('codeIntelCommand', () => {
+  let program: Command;
+  let exitSpy: jest.SpyInstance;
+  let logSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    program = new Command();
+    program.exitOverride();
+    codeIntelCommand(program);
+    mockResolveContext.mockResolvedValue(CTX);
+    exitSpy = jest.spyOn(process, 'exit').mockImplementation((() => {}) as never);
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('symbol', () => {
+    it('fetches and prints a symbol as a table', async () => {
+      const sym = { id: SYMBOL_ID, name: 'AuthService', kind: 'class', file: 'src/auth.ts', startLine: 10, endLine: 50 };
+      mockGetSymbol.mockResolvedValue({ ret: 0, data: sym });
+
+      await program.parseAsync(['node', 'koda', 'code-intel', 'symbol', '--symbol-id', SYMBOL_ID]);
+
+      expect(mockGetSymbol).toHaveBeenCalledWith(expect.objectContaining({ symbolId: SYMBOL_ID }));
+      expect(exitSpy).toHaveBeenCalledWith(0);
+    });
+
+    it('outputs JSON when --json is set', async () => {
+      const sym = { id: SYMBOL_ID, name: 'AuthService', kind: 'class', file: 'src/auth.ts', startLine: 10, endLine: 50 };
+      mockGetSymbol.mockResolvedValue({ ret: 0, data: sym });
+
+      await program.parseAsync(['node', 'koda', 'code-intel', 'symbol', '--symbol-id', SYMBOL_ID, '--json']);
+
+      expect(logSpy).toHaveBeenCalledWith(JSON.stringify(sym, null, 2));
+    });
+
+    it('handles symbol not found', async () => {
+      const err = Object.assign(new Error('Not found'), { status: 404 });
+      mockGetSymbol.mockRejectedValue(err);
+
+      await program.parseAsync(['node', 'koda', 'code-intel', 'symbol', '--symbol-id', SYMBOL_ID]);
+
+      expect(exitSpy).toHaveBeenCalledWith(expect.any(Number));
+    });
+  });
+
+  describe('callers', () => {
+    it('lists callers and prints a table', async () => {
+      const callers = [{ symbolId: 'repo-1:src/app.ts::bootstrap', name: 'bootstrap', file: 'src/app.ts' }];
+      mockGetCallers.mockResolvedValue({ ret: 0, data: callers });
+
+      await program.parseAsync(['node', 'koda', 'code-intel', 'callers', '--symbol-id', SYMBOL_ID]);
+
+      expect(mockGetCallers).toHaveBeenCalledWith(expect.objectContaining({ symbolId: SYMBOL_ID }));
+      expect(exitSpy).toHaveBeenCalledWith(0);
+    });
+
+    it('outputs JSON when --json is set', async () => {
+      const callers = [{ symbolId: 'repo-1:src/app.ts::bootstrap', name: 'bootstrap', file: 'src/app.ts' }];
+      mockGetCallers.mockResolvedValue({ ret: 0, data: callers });
+
+      await program.parseAsync(['node', 'koda', 'code-intel', 'callers', '--symbol-id', SYMBOL_ID, '--json']);
+
+      expect(logSpy).toHaveBeenCalledWith(JSON.stringify(callers, null, 2));
+    });
+  });
+
+  describe('callees', () => {
+    it('lists callees and prints a table', async () => {
+      const callees = [{ symbolId: 'repo-1:src/db.ts::query', name: 'query', file: 'src/db.ts' }];
+      mockGetCallees.mockResolvedValue({ ret: 0, data: callees });
+
+      await program.parseAsync(['node', 'koda', 'code-intel', 'callees', '--symbol-id', SYMBOL_ID]);
+
+      expect(mockGetCallees).toHaveBeenCalledWith(expect.objectContaining({ symbolId: SYMBOL_ID }));
+      expect(exitSpy).toHaveBeenCalledWith(0);
+    });
+
+    it('outputs JSON when --json is set', async () => {
+      const callees = [{ symbolId: 'repo-1:src/db.ts::query', name: 'query', file: 'src/db.ts' }];
+      mockGetCallees.mockResolvedValue({ ret: 0, data: callees });
+
+      await program.parseAsync(['node', 'koda', 'code-intel', 'callees', '--symbol-id', SYMBOL_ID, '--json']);
+
+      expect(logSpy).toHaveBeenCalledWith(JSON.stringify(callees, null, 2));
+    });
+  });
+});

--- a/apps/cli/src/commands/code-intel.ts
+++ b/apps/cli/src/commands/code-intel.ts
@@ -1,0 +1,131 @@
+import { Command } from 'commander';
+import { resolveContext } from '../config';
+import { OpenAPI } from '../generated/core/OpenAPI';
+import {
+  codeIntelControllerGetSymbol,
+  codeIntelControllerGetCallers,
+  codeIntelControllerGetCallees,
+} from '../generated';
+import { table } from '../utils/output';
+import { unwrap } from '../utils/api';
+import { handleApiError } from '../utils/error';
+
+export function codeIntelCommand(program: Command): void {
+  const ci = program.command('code-intel');
+  ci.description('Query code intelligence (symbols, callers, callees)');
+
+  ci
+    .command('symbol')
+    .description('Get a symbol by ID')
+    .requiredOption('--symbol-id <id>', 'Symbol ID ({repoId}:{file}::{Name})')
+    .option('--project <slug>', 'Project slug')
+    .option('--json', 'Output as JSON')
+    .action(async (options) => {
+      try {
+        const ctx = await resolveContext({ projectSlug: options.project });
+        if (!ctx.apiKey || !ctx.apiUrl) {
+          handleApiError(new Error('API key or URL not configured. Run: koda login --api-key <key>'), { configError: true });
+        }
+
+        OpenAPI.BASE = ctx.apiUrl.replace(/\/api\/?$/, '');
+        OpenAPI.TOKEN = ctx.apiKey;
+
+        const response = await codeIntelControllerGetSymbol({
+          symbolId: options.symbolId,
+          projectSlug: ctx.projectSlug ?? options.project,
+        });
+        const data = unwrap<Record<string, unknown>>(response);
+
+        if (options.json) {
+          console.log(JSON.stringify(data, null, 2));
+        } else {
+          const rows = [
+            ['ID', String(data['id'] ?? '')],
+            ['Name', String(data['name'] ?? '')],
+            ['Kind', String(data['kind'] ?? '')],
+            ['File', String(data['file'] ?? '')],
+            ['Lines', `${data['startLine']}–${data['endLine']}`],
+            ['Signature', String(data['signature'] ?? '')],
+          ];
+          table(['Field', 'Value'], rows);
+        }
+        process.exit(0);
+      } catch (err: unknown) {
+        handleApiError(err, { notFoundMessage: `Symbol not found: ${options.symbolId}` });
+      }
+    });
+
+  ci
+    .command('callers')
+    .description('List symbols that call a given symbol')
+    .requiredOption('--symbol-id <id>', 'Symbol ID')
+    .option('--project <slug>', 'Project slug')
+    .option('--json', 'Output as JSON')
+    .action(async (options) => {
+      try {
+        const ctx = await resolveContext({ projectSlug: options.project });
+        if (!ctx.apiKey || !ctx.apiUrl) {
+          handleApiError(new Error('API key or URL not configured. Run: koda login --api-key <key>'), { configError: true });
+        }
+
+        OpenAPI.BASE = ctx.apiUrl.replace(/\/api\/?$/, '');
+        OpenAPI.TOKEN = ctx.apiKey;
+
+        const response = await codeIntelControllerGetCallers({
+          symbolId: options.symbolId,
+          projectSlug: ctx.projectSlug ?? options.project,
+        });
+        const raw = unwrap<{ items?: Array<Record<string, unknown>> } | Array<Record<string, unknown>>>(response);
+        const items: Array<Record<string, unknown>> = Array.isArray(raw)
+          ? raw
+          : ((raw as { items?: Array<Record<string, unknown>> }).items ?? []);
+
+        if (options.json) {
+          console.log(JSON.stringify(items, null, 2));
+        } else {
+          const rows = items.map((s) => [String(s['symbolId'] ?? s['id'] ?? ''), String(s['name'] ?? ''), String(s['file'] ?? '')]);
+          table(['Symbol ID', 'Name', 'File'], rows);
+        }
+        process.exit(0);
+      } catch (err: unknown) {
+        handleApiError(err);
+      }
+    });
+
+  ci
+    .command('callees')
+    .description('List symbols called by a given symbol')
+    .requiredOption('--symbol-id <id>', 'Symbol ID')
+    .option('--project <slug>', 'Project slug')
+    .option('--json', 'Output as JSON')
+    .action(async (options) => {
+      try {
+        const ctx = await resolveContext({ projectSlug: options.project });
+        if (!ctx.apiKey || !ctx.apiUrl) {
+          handleApiError(new Error('API key or URL not configured. Run: koda login --api-key <key>'), { configError: true });
+        }
+
+        OpenAPI.BASE = ctx.apiUrl.replace(/\/api\/?$/, '');
+        OpenAPI.TOKEN = ctx.apiKey;
+
+        const response = await codeIntelControllerGetCallees({
+          symbolId: options.symbolId,
+          projectSlug: ctx.projectSlug ?? options.project,
+        });
+        const raw = unwrap<{ items?: Array<Record<string, unknown>> } | Array<Record<string, unknown>>>(response);
+        const items: Array<Record<string, unknown>> = Array.isArray(raw)
+          ? raw
+          : ((raw as { items?: Array<Record<string, unknown>> }).items ?? []);
+
+        if (options.json) {
+          console.log(JSON.stringify(items, null, 2));
+        } else {
+          const rows = items.map((s) => [String(s['symbolId'] ?? s['id'] ?? ''), String(s['name'] ?? ''), String(s['file'] ?? '')]);
+          table(['Symbol ID', 'Name', 'File'], rows);
+        }
+        process.exit(0);
+      } catch (err: unknown) {
+        handleApiError(err);
+      }
+    });
+}

--- a/apps/cli/src/commands/context.spec.ts
+++ b/apps/cli/src/commands/context.spec.ts
@@ -1,0 +1,121 @@
+jest.mock('chalk', () => ({
+  cyan: { bold: (s: string) => s },
+  gray: (s: string) => s,
+  green: (s: string) => s,
+  red: (s: string) => s,
+  yellow: (s: string) => s,
+}));
+
+const mockData: Record<string, string> = {};
+const mockStore = {
+  get: jest.fn((key: string) => mockData[key] || ''),
+  set: jest.fn((key: string, value: string) => { mockData[key] = value; }),
+};
+jest.mock('conf', () => jest.fn(() => mockStore));
+
+jest.mock('../generated', () => ({
+  contextControllerGetContext: jest.fn(),
+  contextControllerQueryContext: jest.fn(),
+  OpenAPI: { BASE: '', TOKEN: '' },
+}));
+jest.mock('../generated/core/OpenAPI', () => ({ OpenAPI: { BASE: '', TOKEN: '' } }));
+
+jest.mock('../config', () => ({
+  resolveContext: jest.fn(),
+}));
+
+import { Command } from 'commander';
+import { contextCommand } from './context';
+import {
+  contextControllerGetContext,
+  contextControllerQueryContext,
+} from '../generated';
+import { resolveContext } from '../config';
+
+const mockResolveContext = resolveContext as jest.Mock;
+const mockGetContext = contextControllerGetContext as jest.Mock;
+const mockQueryContext = contextControllerQueryContext as jest.Mock;
+
+const CTX = { apiKey: 'sk-test', apiUrl: 'http://localhost:3100/api', projectSlug: 'my-proj' };
+const PROJECT_ID = 'proj-uuid-123';
+
+describe('contextCommand', () => {
+  let program: Command;
+  let exitSpy: jest.SpyInstance;
+  let logSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    program = new Command();
+    program.exitOverride();
+    contextCommand(program);
+    mockResolveContext.mockResolvedValue(CTX);
+    exitSpy = jest.spyOn(process, 'exit').mockImplementation((() => {}) as never);
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('get', () => {
+    it('fetches and prints project context as JSON', async () => {
+      const contextData = { projectId: PROJECT_ID, canonicalState: { tickets: [] } };
+      mockGetContext.mockResolvedValue({ ret: 0, data: contextData });
+
+      await program.parseAsync(['node', 'koda', 'context', 'get', '--project-id', PROJECT_ID]);
+
+      expect(mockGetContext).toHaveBeenCalledWith({ projectId: PROJECT_ID });
+      expect(logSpy).toHaveBeenCalledWith(JSON.stringify(contextData, null, 2));
+      expect(exitSpy).toHaveBeenCalledWith(0);
+    });
+
+    it('handles project not found', async () => {
+      const err = Object.assign(new Error('Not found'), { status: 404 });
+      mockGetContext.mockRejectedValue(err);
+
+      await program.parseAsync(['node', 'koda', 'context', 'get', '--project-id', PROJECT_ID]);
+
+      expect(exitSpy).toHaveBeenCalledWith(expect.any(Number));
+    });
+  });
+
+  describe('query', () => {
+    it('queries context with a prompt and prints result', async () => {
+      const result = { answer: 'some context' };
+      mockQueryContext.mockResolvedValue({ ret: 0, data: result });
+
+      await program.parseAsync([
+        'node', 'koda', 'context', 'query',
+        '--project-id', PROJECT_ID,
+        '--query', 'what is broken',
+        '--intent', 'diagnose',
+      ]);
+
+      expect(mockQueryContext).toHaveBeenCalledWith(expect.objectContaining({
+        projectId: PROJECT_ID,
+        requestBody: expect.objectContaining({ query: 'what is broken', intent: 'diagnose' }),
+      }));
+      expect(logSpy).toHaveBeenCalledWith(JSON.stringify(result, null, 2));
+      expect(exitSpy).toHaveBeenCalledWith(0);
+    });
+
+    it('passes ticket-ids and token-budget', async () => {
+      mockQueryContext.mockResolvedValue({ ret: 0, data: {} });
+
+      await program.parseAsync([
+        'node', 'koda', 'context', 'query',
+        '--project-id', PROJECT_ID,
+        '--ticket-ids', 'tid-1,tid-2',
+        '--token-budget', '4000',
+      ]);
+
+      expect(mockQueryContext).toHaveBeenCalledWith(expect.objectContaining({
+        requestBody: expect.objectContaining({
+          ticketIds: ['tid-1', 'tid-2'],
+          tokenBudget: 4000,
+        }),
+      }));
+    });
+  });
+});

--- a/apps/cli/src/commands/context.ts
+++ b/apps/cli/src/commands/context.ts
@@ -1,0 +1,77 @@
+import { Command } from 'commander';
+import { resolveContext } from '../config';
+import { OpenAPI } from '../generated/core/OpenAPI';
+import {
+  contextControllerGetContext,
+  contextControllerQueryContext,
+} from '../generated';
+import { unwrap } from '../utils/api';
+import { handleApiError } from '../utils/error';
+
+export function contextCommand(program: Command): void {
+  const ctx = program.command('context');
+  ctx.description('Query project context (agent-facing)');
+
+  ctx
+    .command('get')
+    .description('Get full project context by project ID')
+    .requiredOption('--project-id <id>', 'Project UUID')
+    .option('--json', 'Output as JSON')
+    .action(async (options) => {
+      try {
+        const config = await resolveContext({});
+        if (!config.apiKey || !config.apiUrl) {
+          handleApiError(new Error('API key or URL not configured. Run: koda login --api-key <key>'), { configError: true });
+        }
+
+        OpenAPI.BASE = config.apiUrl.replace(/\/api\/?$/, '');
+        OpenAPI.TOKEN = config.apiKey;
+
+        const response = await contextControllerGetContext({ projectId: options.projectId });
+        const data = unwrap<Record<string, unknown>>(response);
+
+        console.log(JSON.stringify(data, null, 2));
+        process.exit(0);
+      } catch (err: unknown) {
+        handleApiError(err, { notFoundMessage: `Project not found: ${options.projectId}` });
+      }
+    });
+
+  ctx
+    .command('query')
+    .description('Query project context with a natural-language prompt')
+    .requiredOption('--project-id <id>', 'Project UUID')
+    .option('--query <text>', 'Natural-language query')
+    .option('--intent <intent>', 'Query intent (e.g. plan, diagnose, review)')
+    .option('--ticket-ids <ids>', 'Comma-separated ticket IDs to scope the query')
+    .option('--token-budget <n>', 'Max token budget for the response', parseInt)
+    .option('--json', 'Output as JSON')
+    .action(async (options) => {
+      try {
+        const config = await resolveContext({});
+        if (!config.apiKey || !config.apiUrl) {
+          handleApiError(new Error('API key or URL not configured. Run: koda login --api-key <key>'), { configError: true });
+        }
+
+        OpenAPI.BASE = config.apiUrl.replace(/\/api\/?$/, '');
+        OpenAPI.TOKEN = config.apiKey;
+
+        const requestBody: Record<string, unknown> = {};
+        if (options.query) requestBody['query'] = options.query;
+        if (options.intent) requestBody['intent'] = options.intent;
+        if (options.ticketIds) requestBody['ticketIds'] = (options.ticketIds as string).split(',').map((s: string) => s.trim()).filter(Boolean);
+        if (options.tokenBudget) requestBody['tokenBudget'] = options.tokenBudget;
+
+        const response = await contextControllerQueryContext({
+          projectId: options.projectId,
+          requestBody,
+        });
+        const data = unwrap<Record<string, unknown>>(response);
+
+        console.log(JSON.stringify(data, null, 2));
+        process.exit(0);
+      } catch (err: unknown) {
+        handleApiError(err, { notFoundMessage: `Project not found: ${options.projectId}` });
+      }
+    });
+}

--- a/apps/cli/src/commands/memory.spec.ts
+++ b/apps/cli/src/commands/memory.spec.ts
@@ -1,0 +1,105 @@
+jest.mock('chalk', () => ({
+  cyan: { bold: (s: string) => s },
+  gray: (s: string) => s,
+  green: (s: string) => s,
+  red: (s: string) => s,
+  yellow: (s: string) => s,
+}));
+
+const mockData: Record<string, string> = {};
+const mockStore = {
+  get: jest.fn((key: string) => mockData[key] || ''),
+  set: jest.fn((key: string, value: string) => { mockData[key] = value; }),
+};
+jest.mock('conf', () => jest.fn(() => mockStore));
+
+jest.mock('../generated', () => ({
+  timelineControllerGetTimeline: jest.fn(),
+  OpenAPI: { BASE: '', TOKEN: '' },
+}));
+jest.mock('../generated/core/OpenAPI', () => ({ OpenAPI: { BASE: '', TOKEN: '' } }));
+
+jest.mock('../config', () => ({
+  resolveContext: jest.fn(),
+}));
+
+import { Command } from 'commander';
+import { memoryCommand } from './memory';
+import { timelineControllerGetTimeline } from '../generated';
+import { resolveContext } from '../config';
+
+const mockResolveContext = resolveContext as jest.Mock;
+const mockGetTimeline = timelineControllerGetTimeline as jest.Mock;
+
+const CTX = { apiKey: 'sk-test', apiUrl: 'http://localhost:3100/api', projectSlug: 'my-proj' };
+
+describe('memoryCommand', () => {
+  let program: Command;
+  let exitSpy: jest.SpyInstance;
+  let logSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    program = new Command();
+    program.exitOverride();
+    memoryCommand(program);
+    mockResolveContext.mockResolvedValue(CTX);
+    exitSpy = jest.spyOn(process, 'exit').mockImplementation((() => {}) as never);
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('timeline', () => {
+    it('fetches timeline and prints a table', async () => {
+      const items = [{ type: 'TICKET_CREATED', actorUserId: 'u-1', ticketId: 't-1', createdAt: '2026-01-01T00:00:00Z' }];
+      mockGetTimeline.mockResolvedValue({ ret: 0, data: items });
+
+      await program.parseAsync(['node', 'koda', 'memory', 'timeline']);
+
+      expect(mockGetTimeline).toHaveBeenCalledWith(expect.objectContaining({ slug: 'my-proj' }));
+      expect(exitSpy).toHaveBeenCalledWith(0);
+    });
+
+    it('outputs JSON when --json flag is set', async () => {
+      const items = [{ type: 'COMMENT', actorUserId: 'u-2', ticketId: 't-2', createdAt: '2026-01-02T00:00:00Z' }];
+      mockGetTimeline.mockResolvedValue({ ret: 0, data: items });
+
+      await program.parseAsync(['node', 'koda', 'memory', 'timeline', '--json']);
+
+      expect(logSpy).toHaveBeenCalledWith(JSON.stringify(items, null, 2));
+    });
+
+    it('passes filter options to the API', async () => {
+      mockGetTimeline.mockResolvedValue({ ret: 0, data: [] });
+
+      await program.parseAsync([
+        'node', 'koda', 'memory', 'timeline',
+        '--actor-id', 'u-1',
+        '--ticket-id', 't-1',
+        '--from', '2026-01-01',
+        '--to', '2026-06-01',
+        '--limit', '10',
+      ]);
+
+      expect(mockGetTimeline).toHaveBeenCalledWith(expect.objectContaining({
+        actorId: 'u-1',
+        ticketId: 't-1',
+        from: '2026-01-01',
+        to: '2026-06-01',
+        limit: '10',
+      }));
+    });
+
+    it('handles empty result gracefully', async () => {
+      mockGetTimeline.mockResolvedValue({ ret: 0, data: [] });
+
+      await program.parseAsync(['node', 'koda', 'memory', 'timeline', '--json']);
+
+      expect(logSpy).toHaveBeenCalledWith('[]');
+      expect(exitSpy).toHaveBeenCalledWith(0);
+    });
+  });
+});

--- a/apps/cli/src/commands/memory.ts
+++ b/apps/cli/src/commands/memory.ts
@@ -1,0 +1,67 @@
+import { Command } from 'commander';
+import { resolveContext } from '../config';
+import { OpenAPI } from '../generated/core/OpenAPI';
+import { timelineControllerGetTimeline } from '../generated';
+import { table } from '../utils/output';
+import { unwrap } from '../utils/api';
+import { handleApiError } from '../utils/error';
+
+export function memoryCommand(program: Command): void {
+  const memory = program.command('memory');
+  memory.description('View project memory and timeline');
+
+  memory
+    .command('timeline')
+    .description('List the event timeline for a project')
+    .option('--project <slug>', 'Project slug')
+    .option('--actor-id <id>', 'Filter by actor (user or agent) ID')
+    .option('--ticket-id <id>', 'Filter by ticket ID')
+    .option('--from <iso>', 'Start of time range (ISO 8601)')
+    .option('--to <iso>', 'End of time range (ISO 8601)')
+    .option('--limit <n>', 'Maximum number of events to return (default: 50)', '50')
+    .option('--cursor <cursor>', 'Pagination cursor')
+    .option('--json', 'Output as JSON')
+    .action(async (options) => {
+      try {
+        const ctx = await resolveContext({ projectSlug: options.project });
+        if (!ctx.projectSlug) {
+          handleApiError(new Error('Project not configured. Run: koda init'), { configError: true });
+        }
+        if (!ctx.apiKey || !ctx.apiUrl) {
+          handleApiError(new Error('API key or URL not configured. Run: koda login --api-key <key>'), { configError: true });
+        }
+
+        OpenAPI.BASE = ctx.apiUrl.replace(/\/api\/?$/, '');
+        OpenAPI.TOKEN = ctx.apiKey;
+
+        const response = await timelineControllerGetTimeline({
+          slug: ctx.projectSlug,
+          actorId: options.actorId,
+          ticketId: options.ticketId,
+          from: options.from,
+          to: options.to,
+          limit: options.limit,
+          cursor: options.cursor,
+        });
+        const raw = unwrap<{ items?: Array<Record<string, unknown>> } | Array<Record<string, unknown>>>(response);
+        const items: Array<Record<string, unknown>> = Array.isArray(raw)
+          ? raw
+          : ((raw as { items?: Array<Record<string, unknown>> }).items ?? []);
+
+        if (options.json) {
+          console.log(JSON.stringify(items, null, 2));
+        } else {
+          const rows = items.map((e) => [
+            String(e['type'] ?? e['action'] ?? ''),
+            String(e['actorId'] ?? e['actorUserId'] ?? e['actorAgentId'] ?? ''),
+            String(e['ticketId'] ?? ''),
+            String(e['createdAt'] ?? ''),
+          ]);
+          table(['Type', 'Actor', 'Ticket', 'Time'], rows);
+        }
+        process.exit(0);
+      } catch (err: unknown) {
+        handleApiError(err);
+      }
+    });
+}

--- a/apps/cli/src/commands/webhook.spec.ts
+++ b/apps/cli/src/commands/webhook.spec.ts
@@ -1,0 +1,134 @@
+jest.mock('chalk', () => ({
+  cyan: { bold: (s: string) => s },
+  gray: (s: string) => s,
+  green: (s: string) => s,
+  red: (s: string) => s,
+  yellow: (s: string) => s,
+}));
+
+const mockData: Record<string, string> = {};
+const mockStore = {
+  get: jest.fn((key: string) => mockData[key] || ''),
+  set: jest.fn((key: string, value: string) => { mockData[key] = value; }),
+};
+jest.mock('conf', () => jest.fn(() => mockStore));
+
+jest.mock('../generated', () => ({
+  webhookControllerRegister: jest.fn(),
+  webhookControllerList: jest.fn(),
+  webhookControllerRemove: jest.fn(),
+  OpenAPI: { BASE: '', TOKEN: '' },
+}));
+jest.mock('../generated/core/OpenAPI', () => ({ OpenAPI: { BASE: '', TOKEN: '' } }));
+
+jest.mock('../config', () => ({
+  resolveContext: jest.fn(),
+}));
+
+import { Command } from 'commander';
+import { webhookCommand } from './webhook';
+import {
+  webhookControllerRegister,
+  webhookControllerList,
+  webhookControllerRemove,
+} from '../generated';
+import { resolveContext } from '../config';
+
+const mockResolveContext = resolveContext as jest.Mock;
+const mockRegister = webhookControllerRegister as jest.Mock;
+const mockList = webhookControllerList as jest.Mock;
+const mockRemove = webhookControllerRemove as jest.Mock;
+
+const CTX = { apiKey: 'sk-test', apiUrl: 'http://localhost:3100/api', projectSlug: 'my-proj' };
+
+describe('webhookCommand', () => {
+  let program: Command;
+  let exitSpy: jest.SpyInstance;
+  let logSpy: jest.SpyInstance;
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    program = new Command();
+    program.exitOverride();
+    webhookCommand(program);
+    mockResolveContext.mockResolvedValue(CTX);
+    exitSpy = jest.spyOn(process, 'exit').mockImplementation((() => {}) as never);
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('create', () => {
+    it('registers a webhook and prints a table', async () => {
+      const webhook = { id: 'wh-1', url: 'https://example.com/hook', events: ['STATUS_CHANGE'] };
+      mockRegister.mockResolvedValue({ ret: 0, data: webhook });
+
+      await program.parseAsync(['node', 'koda', 'webhook', 'create', '--url', 'https://example.com/hook']);
+
+      expect(mockRegister).toHaveBeenCalledWith(expect.objectContaining({ slug: 'my-proj', requestBody: expect.objectContaining({ url: 'https://example.com/hook' }) }));
+      expect(exitSpy).toHaveBeenCalledWith(0);
+    });
+
+    it('outputs JSON when --json flag is set', async () => {
+      const webhook = { id: 'wh-1', url: 'https://example.com/hook', events: ['STATUS_CHANGE'] };
+      mockRegister.mockResolvedValue({ ret: 0, data: webhook });
+
+      await program.parseAsync(['node', 'koda', 'webhook', 'create', '--url', 'https://example.com/hook', '--json']);
+
+      expect(logSpy).toHaveBeenCalledWith(JSON.stringify(webhook, null, 2));
+    });
+
+    it('passes custom events and secret', async () => {
+      mockRegister.mockResolvedValue({ ret: 0, data: { id: 'wh-2', url: 'https://example.com', events: ['COMMENT'] } });
+
+      await program.parseAsync(['node', 'koda', 'webhook', 'create', '--url', 'https://example.com', '--events', 'COMMENT,CREATED', '--secret', 'mysecret']);
+
+      expect(mockRegister).toHaveBeenCalledWith(expect.objectContaining({
+        requestBody: expect.objectContaining({ events: ['COMMENT', 'CREATED'], secret: 'mysecret' }),
+      }));
+    });
+  });
+
+  describe('list', () => {
+    it('lists webhooks and prints a table', async () => {
+      const items = [{ id: 'wh-1', url: 'https://example.com', events: ['STATUS_CHANGE'] }];
+      mockList.mockResolvedValue({ ret: 0, data: items });
+
+      await program.parseAsync(['node', 'koda', 'webhook', 'list']);
+
+      expect(mockList).toHaveBeenCalledWith({ slug: 'my-proj' });
+      expect(exitSpy).toHaveBeenCalledWith(0);
+    });
+
+    it('outputs JSON when --json flag is set', async () => {
+      const items = [{ id: 'wh-1', url: 'https://example.com', events: [] }];
+      mockList.mockResolvedValue({ ret: 0, data: items });
+
+      await program.parseAsync(['node', 'koda', 'webhook', 'list', '--json']);
+
+      expect(logSpy).toHaveBeenCalledWith(JSON.stringify(items, null, 2));
+    });
+  });
+
+  describe('delete', () => {
+    it('deletes a webhook by ID', async () => {
+      mockRemove.mockResolvedValue(undefined);
+
+      await program.parseAsync(['node', 'koda', 'webhook', 'delete', '--id', 'wh-1']);
+
+      expect(mockRemove).toHaveBeenCalledWith({ id: 'wh-1' });
+      expect(exitSpy).toHaveBeenCalledWith(0);
+    });
+
+    it('outputs JSON when --json flag is set', async () => {
+      mockRemove.mockResolvedValue(undefined);
+
+      await program.parseAsync(['node', 'koda', 'webhook', 'delete', '--id', 'wh-1', '--json']);
+
+      expect(logSpy).toHaveBeenCalledWith(JSON.stringify({ deleted: true, id: 'wh-1' }));
+    });
+  });
+});

--- a/apps/cli/src/commands/webhook.ts
+++ b/apps/cli/src/commands/webhook.ts
@@ -1,0 +1,132 @@
+import { Command } from 'commander';
+import { resolveContext } from '../config';
+import { OpenAPI } from '../generated/core/OpenAPI';
+import {
+  webhookControllerRegister,
+  webhookControllerList,
+  webhookControllerRemove,
+} from '../generated';
+import { table } from '../utils/output';
+import { unwrap } from '../utils/api';
+import { handleApiError } from '../utils/error';
+
+export function webhookCommand(program: Command): void {
+  const webhook = program.command('webhook');
+  webhook.description('Manage outbound webhooks');
+
+  webhook
+    .command('create')
+    .description('Register a webhook for a project')
+    .option('--project <slug>', 'Project slug')
+    .requiredOption('--url <url>', 'Webhook endpoint URL')
+    .option('--secret <secret>', 'Signing secret (optional)')
+    .option(
+      '--events <events>',
+      'Comma-separated event types (default: STATUS_CHANGE)',
+      'STATUS_CHANGE',
+    )
+    .option('--json', 'Output as JSON')
+    .action(async (options) => {
+      try {
+        const ctx = await resolveContext({ projectSlug: options.project });
+        if (!ctx.projectSlug) {
+          handleApiError(new Error('Project not configured. Run: koda init'), { configError: true });
+        }
+        if (!ctx.apiKey || !ctx.apiUrl) {
+          handleApiError(new Error('API key or URL not configured. Run: koda login --api-key <key>'), { configError: true });
+        }
+
+        OpenAPI.BASE = ctx.apiUrl.replace(/\/api\/?$/, '');
+        OpenAPI.TOKEN = ctx.apiKey;
+
+        const events = (options.events as string).split(',').map((e: string) => e.trim()).filter(Boolean);
+        const response = await webhookControllerRegister({
+          slug: ctx.projectSlug,
+          requestBody: { url: options.url, secret: options.secret, events },
+        });
+        const data = unwrap<{ id: string; url: string; events: string[] }>(response);
+
+        if (options.json) {
+          console.log(JSON.stringify(data, null, 2));
+        } else {
+          const rows = [
+            ['ID', data.id],
+            ['URL', data.url],
+            ['Events', (data.events ?? []).join(', ')],
+          ];
+          table(['Field', 'Value'], rows);
+        }
+        process.exit(0);
+      } catch (err: unknown) {
+        handleApiError(err);
+      }
+    });
+
+  webhook
+    .command('list')
+    .description('List webhooks for a project')
+    .option('--project <slug>', 'Project slug')
+    .option('--json', 'Output as JSON')
+    .action(async (options) => {
+      try {
+        const ctx = await resolveContext({ projectSlug: options.project });
+        if (!ctx.projectSlug) {
+          handleApiError(new Error('Project not configured. Run: koda init'), { configError: true });
+        }
+        if (!ctx.apiKey || !ctx.apiUrl) {
+          handleApiError(new Error('API key or URL not configured. Run: koda login --api-key <key>'), { configError: true });
+        }
+
+        OpenAPI.BASE = ctx.apiUrl.replace(/\/api\/?$/, '');
+        OpenAPI.TOKEN = ctx.apiKey;
+
+        const response = await webhookControllerList({ slug: ctx.projectSlug });
+        const raw = unwrap<{ items?: Array<Record<string, unknown>> } | Array<Record<string, unknown>>>(response);
+        const items: Array<Record<string, unknown>> = Array.isArray(raw)
+          ? raw
+          : ((raw as { items?: Array<Record<string, unknown>> }).items ?? []);
+
+        if (options.json) {
+          console.log(JSON.stringify(items, null, 2));
+        } else {
+          const rows = items.map((w) => [
+            String(w['id'] ?? ''),
+            String(w['url'] ?? ''),
+            Array.isArray(w['events']) ? (w['events'] as string[]).join(', ') : String(w['events'] ?? ''),
+          ]);
+          table(['ID', 'URL', 'Events'], rows);
+        }
+        process.exit(0);
+      } catch (err: unknown) {
+        handleApiError(err);
+      }
+    });
+
+  webhook
+    .command('delete')
+    .description('Delete a webhook by ID')
+    .requiredOption('--id <id>', 'Webhook ID')
+    .option('--json', 'Output as JSON')
+    .action(async (options) => {
+      try {
+        const ctx = await resolveContext({});
+        if (!ctx.apiKey || !ctx.apiUrl) {
+          handleApiError(new Error('API key or URL not configured. Run: koda login --api-key <key>'), { configError: true });
+        }
+
+        OpenAPI.BASE = ctx.apiUrl.replace(/\/api\/?$/, '');
+        OpenAPI.TOKEN = ctx.apiKey;
+
+        await webhookControllerRemove({ id: options.id });
+
+        if (options.json) {
+          console.log(JSON.stringify({ deleted: true, id: options.id }));
+        } else {
+          console.log(`Webhook '${options.id}' deleted.`);
+        }
+        process.exit(0);
+      } catch (err: unknown) {
+        handleApiError(err, { notFoundMessage: `Webhook not found: ${options.id}` });
+      }
+    });
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -14,6 +14,10 @@ import { labelCommand } from './commands/label';
 import { kbCommand } from './commands/kb';
 import { evaluateCommand } from './commands/evaluate';
 import { vcsCommand } from './commands/vcs';
+import { webhookCommand } from './commands/webhook';
+import { contextCommand } from './commands/context';
+import { memoryCommand } from './commands/memory';
+import { codeIntelCommand } from './commands/code-intel';
 
 // Read package.json to get version
 let version = '0.1.0';
@@ -161,6 +165,18 @@ evaluateCommand(program);
 
 // VCS command
 vcsCommand(program);
+
+// Webhook command
+webhookCommand(program);
+
+// Context command
+contextCommand(program);
+
+// Memory command
+memoryCommand(program);
+
+// Code-intel command
+codeIntelCommand(program);
 
 // Global error handling for uncaught exceptions
 process.on('uncaughtException', (error: Error) => {


### PR DESCRIPTION
## Summary

- Adds `koda webhook create/list/delete` — register, list, and remove outbound webhooks per project
- Adds `koda context get/query` — fetch full project context or query it with a natural-language prompt (agent-facing)
- Adds `koda memory timeline` — list the project event timeline with actor/ticket/time filters
- Adds `koda code-intel symbol/callers/callees` — look up symbols and navigate the call graph

All commands follow the established CLI pattern: resolve context → set `OpenAPI.BASE`/`TOKEN` → call generated client → `unwrap()` the envelope → output table (default) or JSON (`--json`). Each command file has a companion `.spec.ts` covering happy paths and `--json` output.

## Test plan

- [x] `bun run test --filter @nathapp/koda-cli` — 28 suites / 446 tests pass
- [x] `bun run lint --filter @nathapp/koda-cli` — no lint errors
- [x] All 4 new command files lint-clean and covered