### PR TITLE
feat: add GET/PATCH /projects/:slug/agents endpoints (fix issue #98)

### DIFF
--- a/apps/api/src/agents/agents.service.spec.ts
+++ b/apps/api/src/agents/agents.service.spec.ts
@@ -2,7 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { AgentsService, CreateAgentDto as _CreateAgentDto } from './agents.service';
 import { PrismaAgentRepository } from './prisma-agent.repository';
 import { ConfigService } from '@nestjs/config';
-import { ValidationAppException } from '@nathapp/nestjs-common';
+import { NotFoundAppException, ValidationAppException } from '@nathapp/nestjs-common';
 import { createHmac } from 'crypto';
 import { randomBytes } from 'crypto';
 import { KodaDomainWriter } from '../koda-domain-writer/koda-domain-writer.service';
@@ -70,6 +70,7 @@ describe('AgentsService', () => {
     replaceCapabilities: jest.fn(),
     findProjectBySlug: jest.fn(),
     findVerifiedUnassignedTickets: jest.fn(),
+    findByProjectSlug: jest.fn(),
   };
 
   const mockConfigService = {
@@ -779,6 +780,40 @@ describe('AgentsService', () => {
       expect(safeResult.ticket.id).toBe('unassigned-ticket');
       // Verify the repo was called with the project id
       expect(agentRepo.findVerifiedUnassignedTickets).toHaveBeenCalledWith('project-1');
+    });
+  });
+
+  describe('findByProject', () => {
+    it('returns agents derived from project tickets', async () => {
+      const mockRepoResult = {
+        project: { id: 'proj-1', slug: 'alpha' },
+        agents: [
+          {
+            id: 'agent-1',
+            name: 'Bot',
+            slug: 'bot',
+            status: 'ACTIVE',
+            maxConcurrentTickets: 3,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            roles: [{ id: 'r1', agentId: 'agent-1', role: 'DEVELOPER' }],
+            capabilities: [{ id: 'c1', agentId: 'agent-1', capability: 'typescript' }],
+          },
+        ],
+      };
+      mockAgentRepo.findByProjectSlug.mockResolvedValue(mockRepoResult);
+
+      const result = await service.findByProject('alpha');
+
+      expect(mockAgentRepo.findByProjectSlug).toHaveBeenCalledWith('alpha');
+      expect(result).toHaveLength(1);
+      expect(result[0].slug).toBe('bot');
+    });
+
+    it('throws NotFoundAppException when project does not exist', async () => {
+      mockAgentRepo.findByProjectSlug.mockResolvedValue(null);
+
+      await expect(service.findByProject('nonexistent')).rejects.toThrow(NotFoundAppException);
     });
   });
 

--- a/apps/api/src/agents/agents.service.ts
+++ b/apps/api/src/agents/agents.service.ts
@@ -199,6 +199,12 @@ export class AgentsService {
     return AgentResponseDto.from(agent);
   }
 
+  async findByProject(projectSlug: string): Promise<AgentResponseDto[]> {
+    const result = await this.agentRepo.findByProjectSlug(projectSlug);
+    if (!result) throw new NotFoundAppException({}, 'projects');
+    return AgentResponseDto.fromMany(result.agents);
+  }
+
   async update(slug: string, updateData: UpdateAgentDto): Promise<AgentResponseDto> {
     const existing = await this.agentRepo.findBySlugScalar(slug);
     if (!existing) throw new NotFoundAppException({}, 'agents');

--- a/apps/api/src/agents/prisma-agent.repository.ts
+++ b/apps/api/src/agents/prisma-agent.repository.ts
@@ -111,6 +111,28 @@ export class PrismaAgentRepository {
     return this.db.project.findUnique({ where: { slug } });
   }
 
+  async findByProjectSlug(projectSlug: string) {
+    const project = await this.db.project.findUnique({
+      where: { slug: projectSlug },
+      select: { id: true, slug: true },
+    });
+    if (!project) return null;
+
+    const agents = await this.db.agent.findMany({
+      where: {
+        assignedTickets: {
+          some: {
+            projectId: project.id,
+            deletedAt: null,
+          },
+        },
+      },
+      include: { roles: true, capabilities: true },
+    });
+
+    return { project, agents };
+  }
+
   async findVerifiedUnassignedTickets(projectId: string) {
     return this.db.ticket.findMany({
       where: {

--- a/apps/api/src/common/test-helpers/global-stubs.module.ts
+++ b/apps/api/src/common/test-helpers/global-stubs.module.ts
@@ -31,6 +31,9 @@ export const mockCacheManager = {
 @Global()
 @Module({
   imports: [
+    // ConfigModule.forRoot is required here (not a lightweight mock) because
+    // ProjectsModule → AgentsModule → NathappAuthModule.forRootAsync requires a
+    // real ConfigService that can resolve the JWT config object structure.
     ConfigModule.forRoot({
       isGlobal: true,
       load: [authConfig],

--- a/apps/api/src/common/test-helpers/global-stubs.module.ts
+++ b/apps/api/src/common/test-helpers/global-stubs.module.ts
@@ -1,5 +1,5 @@
 import { Global, Module } from '@nestjs/common';
-import { ConfigModule, ConfigService } from '@nestjs/config';
+import { ConfigModule } from '@nestjs/config';
 import { PrismaService } from '@nathapp/nestjs-prisma';
 import { ITransactionManager, TRANSACTION_MANAGER } from '@nathapp/nestjs-data';
 import { CacheManager } from '@nathapp/nestjs-cache';
@@ -16,10 +16,6 @@ export const mockTransactionManager: ITransactionManager = {
   getClient: () => undefined,
   isInTransaction: () => false,
 };
-
-export const mockConfigService = {
-  get: <T = unknown>(key?: string): T | undefined => key as unknown as T,
-} as unknown as ConfigService;
 
 export const mockAgentsService = {
   findByProject: async () => [],

--- a/apps/api/src/common/test-helpers/global-stubs.module.ts
+++ b/apps/api/src/common/test-helpers/global-stubs.module.ts
@@ -1,8 +1,11 @@
 import { Global, Module } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 import { PrismaService } from '@nathapp/nestjs-prisma';
 import { ITransactionManager, TRANSACTION_MANAGER } from '@nathapp/nestjs-data';
+import { CacheManager } from '@nathapp/nestjs-cache';
 import { PrismaProjectRepository } from '../../projects/prisma-project.repository';
+import { AgentsService } from '../../agents/agents.service';
+import { authConfig } from '../../config/auth.config';
 
 export const mockPrismaService = {
   client: {},
@@ -18,14 +21,33 @@ export const mockConfigService = {
   get: <T = unknown>(key?: string): T | undefined => key as unknown as T,
 } as unknown as ConfigService;
 
+export const mockAgentsService = {
+  findByProject: async () => [],
+  update: async () => undefined,
+} as unknown as AgentsService;
+
+export const mockCacheManager = {
+  get: async () => undefined,
+  set: async () => undefined,
+  del: async () => undefined,
+} as unknown as CacheManager;
+
 @Global()
 @Module({
+  imports: [
+    ConfigModule.forRoot({
+      isGlobal: true,
+      load: [authConfig],
+      envFilePath: ['.env.test'],
+    }),
+  ],
   providers: [
     { provide: PrismaService, useValue: mockPrismaService },
     { provide: TRANSACTION_MANAGER, useValue: mockTransactionManager },
-    { provide: ConfigService, useValue: mockConfigService },
     PrismaProjectRepository,
+    { provide: AgentsService, useValue: mockAgentsService },
+    { provide: CacheManager, useValue: mockCacheManager },
   ],
-  exports: [PrismaService, TRANSACTION_MANAGER, ConfigService, PrismaProjectRepository],
+  exports: [PrismaService, TRANSACTION_MANAGER, ConfigModule, PrismaProjectRepository, AgentsService, CacheManager],
 })
 export class GlobalStubsModule {}

--- a/apps/api/src/projects/projects.controller.spec.ts
+++ b/apps/api/src/projects/projects.controller.spec.ts
@@ -4,6 +4,7 @@ import { ProjectsController } from './projects.controller';
 import { ProjectsService } from './projects.service';
 import { PrismaMemoryItemRepository } from '../memory/prisma-memory-item.repository';
 import { ImpactAnalysisService } from '../code-intel/impact-analysis.service';
+import { AgentsService } from '../agents/agents.service';
 import { ForbiddenAppException } from '@nathapp/nestjs-common';
 import { PrismaService } from '@nathapp/nestjs-prisma';
 import type { KodaPrincipal } from '../auth/principal/koda-principal.types';
@@ -67,6 +68,7 @@ describe('ProjectsController', () => {
   let projectsService: jest.Mocked<ProjectsService>;
   let memoryItemRepository: jest.Mocked<PrismaMemoryItemRepository>;
   let impactAnalysisService: jest.Mocked<ImpactAnalysisService>;
+  let agentsService: jest.Mocked<AgentsService>;
 
   const mockProjectMemberFindUnique = jest.fn();
   const mockPrismaClient = {
@@ -91,6 +93,11 @@ describe('ProjectsController', () => {
       getChangeImpact: jest.fn(),
     } as unknown as jest.Mocked<ImpactAnalysisService>;
 
+    agentsService = {
+      findByProject: jest.fn(),
+      update: jest.fn(),
+    } as unknown as jest.Mocked<AgentsService>;
+
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ProjectsController],
       providers: [
@@ -98,6 +105,7 @@ describe('ProjectsController', () => {
         { provide: PrismaMemoryItemRepository, useValue: memoryItemRepository },
         { provide: ImpactAnalysisService, useValue: impactAnalysisService },
         { provide: PrismaService, useValue: mockPrismaService },
+        { provide: AgentsService, useValue: agentsService },
       ],
     }).compile();
 
@@ -301,6 +309,105 @@ describe('ProjectsController', () => {
 
       await expect(
         controller.getChangeImpact('alpha', 'repo-1', 'abc', 'file.ts', memberPrincipal),
+      ).rejects.toThrow(ForbiddenAppException);
+    });
+  });
+
+  describe('getProjectAgents', () => {
+    const mockAgent = {
+      id: 'agent-1',
+      name: 'Bot',
+      slug: 'bot',
+      status: 'ACTIVE',
+      maxConcurrentTickets: 3,
+      roles: [],
+      capabilities: [],
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    it('returns agents for a project (admin bypasses membership check)', async () => {
+      projectsService.findBySlug.mockResolvedValue(mockProject as any);
+      agentsService.findByProject.mockResolvedValue([mockAgent] as any);
+
+      const result = await controller.getProjectAgents('alpha', adminPrincipal);
+
+      expect(projectsService.findBySlug).toHaveBeenCalledWith('alpha');
+      expect(agentsService.findByProject).toHaveBeenCalledWith('alpha');
+      expect((result as any).data).toHaveLength(1);
+      expect((result as any).data[0].slug).toBe('bot');
+    });
+
+    it('returns agents for a project member', async () => {
+      projectsService.findBySlug.mockResolvedValue(mockProject as any);
+      mockProjectMemberFindUnique.mockResolvedValue({ role: 'DEVELOPER' });
+      agentsService.findByProject.mockResolvedValue([mockAgent] as any);
+
+      const result = await controller.getProjectAgents('alpha', memberPrincipal);
+
+      expect((result as any).data).toHaveLength(1);
+    });
+
+    it('throws ForbiddenAppException for non-member', async () => {
+      projectsService.findBySlug.mockResolvedValue(mockProject as any);
+      mockProjectMemberFindUnique.mockResolvedValue(null);
+
+      await expect(
+        controller.getProjectAgents('alpha', memberPrincipal),
+      ).rejects.toThrow(ForbiddenAppException);
+    });
+
+    it('allows agent principals without membership check', async () => {
+      projectsService.findBySlug.mockResolvedValue(mockProject as any);
+      agentsService.findByProject.mockResolvedValue([mockAgent] as any);
+
+      const result = await controller.getProjectAgents('alpha', agentPrincipal);
+
+      expect(mockProjectMemberFindUnique).not.toHaveBeenCalled();
+      expect((result as any).data).toHaveLength(1);
+    });
+  });
+
+  describe('updateProjectAgent', () => {
+    const mockUpdatedAgent = {
+      id: 'agent-1',
+      name: 'Bot',
+      slug: 'bot',
+      status: 'PAUSED',
+      maxConcurrentTickets: 3,
+      roles: [],
+      capabilities: [],
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    it('updates agent status for admin principal', async () => {
+      projectsService.findBySlug.mockResolvedValue(mockProject as any);
+      agentsService.update.mockResolvedValue(mockUpdatedAgent as any);
+
+      const result = await controller.updateProjectAgent('alpha', 'bot', { status: 'PAUSED' }, adminPrincipal);
+
+      expect(projectsService.findBySlug).toHaveBeenCalledWith('alpha');
+      expect(agentsService.update).toHaveBeenCalledWith('bot', { status: 'PAUSED' });
+      expect((result as any).data.status).toBe('PAUSED');
+    });
+
+    it('updates agent status for project member', async () => {
+      projectsService.findBySlug.mockResolvedValue(mockProject as any);
+      mockProjectMemberFindUnique.mockResolvedValue({ role: 'DEVELOPER' });
+      agentsService.update.mockResolvedValue(mockUpdatedAgent as any);
+
+      const result = await controller.updateProjectAgent('alpha', 'bot', { status: 'PAUSED' }, memberPrincipal);
+
+      expect((result as any).data.status).toBe('PAUSED');
+    });
+
+    it('throws ForbiddenAppException for non-member', async () => {
+      projectsService.findBySlug.mockResolvedValue(mockProject as any);
+      mockProjectMemberFindUnique.mockResolvedValue(null);
+
+      await expect(
+        controller.updateProjectAgent('alpha', 'bot', { status: 'PAUSED' }, memberPrincipal),
       ).rejects.toThrow(ForbiddenAppException);
     });
   });

--- a/apps/api/src/projects/projects.controller.spec.ts
+++ b/apps/api/src/projects/projects.controller.spec.ts
@@ -5,7 +5,7 @@ import { ProjectsService } from './projects.service';
 import { PrismaMemoryItemRepository } from '../memory/prisma-memory-item.repository';
 import { ImpactAnalysisService } from '../code-intel/impact-analysis.service';
 import { AgentsService } from '../agents/agents.service';
-import { ForbiddenAppException } from '@nathapp/nestjs-common';
+import { ForbiddenAppException, NotFoundAppException } from '@nathapp/nestjs-common';
 import { PrismaService } from '@nathapp/nestjs-prisma';
 import type { KodaPrincipal } from '../auth/principal/koda-principal.types';
 
@@ -383,6 +383,7 @@ describe('ProjectsController', () => {
 
     it('updates agent status for admin principal', async () => {
       projectsService.findBySlug.mockResolvedValue(mockProject as any);
+      agentsService.findByProject.mockResolvedValue([mockUpdatedAgent] as any);
       agentsService.update.mockResolvedValue(mockUpdatedAgent as any);
 
       const result = await controller.updateProjectAgent('alpha', 'bot', { status: 'PAUSED' }, adminPrincipal);
@@ -395,6 +396,7 @@ describe('ProjectsController', () => {
     it('updates agent status for project member', async () => {
       projectsService.findBySlug.mockResolvedValue(mockProject as any);
       mockProjectMemberFindUnique.mockResolvedValue({ role: 'DEVELOPER' });
+      agentsService.findByProject.mockResolvedValue([mockUpdatedAgent] as any);
       agentsService.update.mockResolvedValue(mockUpdatedAgent as any);
 
       const result = await controller.updateProjectAgent('alpha', 'bot', { status: 'PAUSED' }, memberPrincipal);
@@ -409,6 +411,16 @@ describe('ProjectsController', () => {
       await expect(
         controller.updateProjectAgent('alpha', 'bot', { status: 'PAUSED' }, memberPrincipal),
       ).rejects.toThrow(ForbiddenAppException);
+    });
+
+    it('throws NotFoundAppException when agent is not in the project', async () => {
+      projectsService.findBySlug.mockResolvedValue(mockProject as any);
+      mockProjectMemberFindUnique.mockResolvedValue({ role: 'DEVELOPER' });
+      agentsService.findByProject.mockResolvedValue([]);
+
+      await expect(
+        controller.updateProjectAgent('alpha', 'bot', { status: 'PAUSED' }, memberPrincipal),
+      ).rejects.toThrow(NotFoundAppException);
     });
   });
 });

--- a/apps/api/src/projects/projects.controller.ts
+++ b/apps/api/src/projects/projects.controller.ts
@@ -30,6 +30,8 @@ import { KodaPrincipal, isUserPrincipal } from '../auth/principal/koda-principal
 import { ActorRole } from '../common/enums';
 import { ImpactAnalysisService } from '../code-intel/impact-analysis.service';
 import { KodaAction } from '../auth/casl/koda-action.enum';
+import { AgentsService } from '../agents/agents.service';
+import { UpdateAgentDto } from '../agents/dto/update-agent.dto';
 
 @ApiTags('projects')
 @ApiBearerAuth()
@@ -40,6 +42,7 @@ export class ProjectsController {
     private memoryItemRepository: PrismaMemoryItemRepository,
     private impactAnalysisService: ImpactAnalysisService,
     private prisma: PrismaService,
+    private agentsService: AgentsService,
   ) {}
 
   private get db() { return this.prisma.client as unknown as { projectMember: { findUnique(options: unknown): Promise<unknown> } }; }
@@ -222,5 +225,39 @@ export class ProjectsController {
     });
 
     return JsonResponse.Ok(result);
+  }
+
+  @Get(':slug/agents')
+  @ApiOperation({ summary: 'List agents active in a project (derived from assigned tickets)' })
+  @ApiResponse({ status: 200, description: 'Agents retrieved successfully' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - no project access' })
+  @ApiResponse({ status: 404, description: 'Project not found' })
+  async getProjectAgents(
+    @Param('slug') slug: string,
+    @Principal() principal: KodaPrincipal,
+  ) {
+    const project = await this.projectsService.findBySlug(slug);
+    await this.checkProjectMembership(project.id, principal);
+    const data = await this.agentsService.findByProject(slug);
+    return JsonResponse.Ok(data);
+  }
+
+  @Patch(':slug/agents/:agentSlug')
+  @ApiOperation({ summary: 'Update an agent status within a project context (admin or project member)' })
+  @ApiResponse({ status: 200, description: 'Agent updated successfully' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - no project access' })
+  @ApiResponse({ status: 404, description: 'Project or agent not found' })
+  async updateProjectAgent(
+    @Param('slug') slug: string,
+    @Param('agentSlug') agentSlug: string,
+    @Body() updateDto: UpdateAgentDto,
+    @Principal() principal: KodaPrincipal,
+  ) {
+    const project = await this.projectsService.findBySlug(slug);
+    await this.checkProjectMembership(project.id, principal);
+    const data = await this.agentsService.update(agentSlug, updateDto);
+    return JsonResponse.Ok(data);
   }
 }

--- a/apps/api/src/projects/projects.controller.ts
+++ b/apps/api/src/projects/projects.controller.ts
@@ -24,7 +24,7 @@ import {
 } from '@nestjs/swagger';
 import { PrismaMemoryItemRepository } from '../memory/prisma-memory-item.repository';
 import { PrismaService } from '@nathapp/nestjs-prisma';
-import { ForbiddenAppException } from '@nathapp/nestjs-common';
+import { ForbiddenAppException, NotFoundAppException } from '@nathapp/nestjs-common';
 import { Principal, RequiredPermission, CaslPermissionAction } from '@nathapp/nestjs-auth';
 import { KodaPrincipal, isUserPrincipal } from '../auth/principal/koda-principal.types';
 import { ActorRole } from '../common/enums';
@@ -257,6 +257,10 @@ export class ProjectsController {
   ) {
     const project = await this.projectsService.findBySlug(slug);
     await this.checkProjectMembership(project.id, principal);
+    const projectAgents = await this.agentsService.findByProject(slug);
+    if (!projectAgents.some((a) => a.slug === agentSlug)) {
+      throw new NotFoundAppException({}, 'agents');
+    }
     const data = await this.agentsService.update(agentSlug, updateDto);
     return JsonResponse.Ok(data);
   }

--- a/apps/api/src/projects/projects.module.spec.ts
+++ b/apps/api/src/projects/projects.module.spec.ts
@@ -1,0 +1,36 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ProjectsController } from './projects.controller';
+import { ProjectsService } from './projects.service';
+import { AgentsService } from '../agents/agents.service';
+import { PrismaMemoryItemRepository } from '../memory/prisma-memory-item.repository';
+import { ImpactAnalysisService } from '../code-intel/impact-analysis.service';
+import { PrismaService } from '@nathapp/nestjs-prisma';
+
+describe('ProjectsModule — DI wiring', () => {
+  let module: TestingModule;
+
+  beforeEach(async () => {
+    module = await Test.createTestingModule({
+      controllers: [ProjectsController],
+      providers: [
+        { provide: ProjectsService, useValue: {} },
+        { provide: AgentsService, useValue: {} },
+        { provide: PrismaMemoryItemRepository, useValue: {} },
+        { provide: ImpactAnalysisService, useValue: {} },
+        {
+          provide: PrismaService,
+          useValue: { client: { projectMember: { findUnique: jest.fn() } } },
+        },
+      ],
+    }).compile();
+  });
+
+  afterEach(async () => {
+    await module.close();
+  });
+
+  it('ProjectsController resolves with AgentsService injected', () => {
+    const controller = module.get(ProjectsController);
+    expect(controller).toBeDefined();
+  });
+});

--- a/apps/api/src/projects/projects.module.ts
+++ b/apps/api/src/projects/projects.module.ts
@@ -7,9 +7,10 @@ import { PROJECT_REPOSITORY } from './domain/project.domain';
 import { RagModule } from '../rag/rag.module';
 import { MemoryModule } from '../memory/memory.module';
 import { CodeIntelModule } from '../code-intel/code-intel.module';
+import { AgentsModule } from '../agents/agents.module';
 
 @Module({
-  imports: [PrismaModule, RagModule, MemoryModule, CodeIntelModule],
+  imports: [PrismaModule, RagModule, MemoryModule, CodeIntelModule, AgentsModule],
   controllers: [ProjectsController],
   providers: [
     PrismaProjectRepository,

--- a/apps/api/test/e2e/api-endpoint/endpoint.e2e.spec.ts
+++ b/apps/api/test/e2e/api-endpoint/endpoint.e2e.spec.ts
@@ -1194,6 +1194,29 @@ describeIntegration('API Integration Tests', () => {
   // ─────────────────────────────────────────────────────────────────
 
   describe('19b. Project-Scoped Agent Routes', () => {
+    beforeAll(async () => {
+      // The assign endpoint requires the agent's Prisma ID, not slug.
+      // Fetch it first, then create and assign a ticket so agentSlug appears in the project agents list.
+      const agentRes = await request(httpServer)
+        .get(`/api/agents/${agentSlug}`)
+        .set('Authorization', `Bearer ${userAccessToken}`)
+        .expect(200);
+      const agentId = body<{ id: string }>(agentRes).id;
+
+      const ticketRes = await request(httpServer)
+        .post(`/api/projects/${projectSlug}/tickets`)
+        .set('Authorization', `Bearer ${userAccessToken}`)
+        .send({ type: 'BUG', title: '19b assignment target', priority: 'LOW' })
+        .expect(201);
+      const ticketRef = body<{ ref: string }>(ticketRes).ref;
+
+      await request(httpServer)
+        .post(`/api/projects/${projectSlug}/tickets/${ticketRef}/assign`)
+        .set('Authorization', `Bearer ${userAccessToken}`)
+        .send({ agentId })
+        .expect(200);
+    });
+
     it('GET /api/projects/:slug/agents — 200 returns agents with assigned tickets', async () => {
       const res = await request(httpServer)
         .get(`/api/projects/${projectSlug}/agents`)
@@ -1202,7 +1225,7 @@ describeIntegration('API Integration Tests', () => {
 
       const data = body<{ id: string; slug: string; status: string }[]>(res);
       expect(Array.isArray(data)).toBe(true);
-      // agentSlug was assigned a ticket in section 18; it must appear in the list
+      // agentSlug has an assigned ticket (set up in beforeAll); it must appear in the list
       const found = data.find((a) => a.slug === agentSlug);
       expect(found).toBeDefined();
       expect(found?.status).toBeDefined();

--- a/apps/api/test/e2e/api-endpoint/endpoint.e2e.spec.ts
+++ b/apps/api/test/e2e/api-endpoint/endpoint.e2e.spec.ts
@@ -1189,6 +1189,74 @@ describeIntegration('API Integration Tests', () => {
     });
 
   // ─────────────────────────────────────────────────────────────────
+  // 19b. Project-Scoped Agent Routes
+  // ─────────────────────────────────────────────────────────────────
+
+  describe('19b. Project-Scoped Agent Routes', () => {
+    it('GET /api/projects/:slug/agents — 200 returns agents with assigned tickets', async () => {
+      const res = await request(httpServer)
+        .get(`/api/projects/${projectSlug}/agents`)
+        .set('Authorization', `Bearer ${userAccessToken}`)
+        .expect(200);
+
+      const data = body<{ id: string; slug: string; status: string }[]>(res);
+      expect(Array.isArray(data)).toBe(true);
+      // agentSlug was assigned a ticket in section 18; it must appear in the list
+      const found = data.find((a) => a.slug === agentSlug);
+      expect(found).toBeDefined();
+      expect(found?.status).toBeDefined();
+    });
+
+    it('GET /api/projects/:slug/agents — 401 without auth token', async () => {
+      await request(httpServer)
+        .get(`/api/projects/${projectSlug}/agents`)
+        .expect(401);
+    });
+
+    it('GET /api/projects/nonexistent/agents — 404 for unknown project slug', async () => {
+      await request(httpServer)
+        .get('/api/projects/no-such-project/agents')
+        .set('Authorization', `Bearer ${userAccessToken}`)
+        .expect(404);
+    });
+
+    it('PATCH /api/projects/:slug/agents/:agentSlug — 200 updates agent status', async () => {
+      const res = await request(httpServer)
+        .patch(`/api/projects/${projectSlug}/agents/${agentSlug}`)
+        .set('Authorization', `Bearer ${userAccessToken}`)
+        .send({ status: 'PAUSED' })
+        .expect(200);
+
+      const data = body<{ slug: string; status: string }>(res);
+      expect(data.slug).toBe(agentSlug);
+      expect(data.status).toBe('PAUSED');
+
+      // Restore to ACTIVE so downstream tests are not affected
+      await request(httpServer)
+        .patch(`/api/projects/${projectSlug}/agents/${agentSlug}`)
+        .set('Authorization', `Bearer ${userAccessToken}`)
+        .send({ status: 'ACTIVE' })
+        .expect(200);
+    });
+
+    it('PATCH /api/projects/:slug/agents/nonexistent — 404 for unknown agent slug', async () => {
+      await request(httpServer)
+        .patch(`/api/projects/${projectSlug}/agents/no-such-agent`)
+        .set('Authorization', `Bearer ${userAccessToken}`)
+        .send({ status: 'PAUSED' })
+        .expect(404);
+    });
+
+    it('PATCH /api/projects/:slug/agents/:agentSlug — 403 for non-member user', async () => {
+      await request(httpServer)
+        .patch(`/api/projects/${projectSlug}/agents/${agentSlug}`)
+        .set('Authorization', `Bearer ${nonAdminUserAccessToken}`)
+        .send({ status: 'PAUSED' })
+        .expect(403);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────
   // 18. Ticket Links
   // ─────────────────────────────────────────────────────────────────
 

--- a/apps/api/test/e2e/api-endpoint/endpoint.e2e.spec.ts
+++ b/apps/api/test/e2e/api-endpoint/endpoint.e2e.spec.ts
@@ -1187,6 +1187,7 @@ describeIntegration('API Integration Tests', () => {
         .set('Authorization', `Bearer ${userAccessToken}`)
         .expect(404);
     });
+  });
 
   // ─────────────────────────────────────────────────────────────────
   // 19b. Project-Scoped Agent Routes
@@ -1460,34 +1461,33 @@ describeIntegration('API Integration Tests', () => {
     });
   });
 
-    it('GET /api/agents/:slug/pickup — returns null data when no VERIFIED unassigned tickets remain', async () => {
-      // Create an agent with no matching tickets in a non-existent project
-      // Use a project slug that does not exist to get a null result
-      // (project not found should still return null gracefully, or 404 for project)
-      // We test the null path by using a fresh agent with no VERIFIED tickets
-      const freshAgentRes = await request(httpServer)
-        .post('/api/agents')
-        .set('Authorization', `Bearer ${userAccessToken}`)
-        .send({ name: 'Pickup Empty Agent', slug: 'pickup-empty-agent', roles: ['DEVELOPER'] })
-        .expect(201);
+  it('GET /api/agents/:slug/pickup — returns null data when no VERIFIED unassigned tickets remain', async () => {
+    // Create an agent with no matching tickets in a non-existent project
+    // Use a project slug that does not exist to get a null result
+    // (project not found should still return null gracefully, or 404 for project)
+    // We test the null path by using a fresh agent with no VERIFIED tickets
+    const freshAgentRes = await request(httpServer)
+      .post('/api/agents')
+      .set('Authorization', `Bearer ${userAccessToken}`)
+      .send({ name: 'Pickup Empty Agent', slug: 'pickup-empty-agent', roles: ['DEVELOPER'] })
+      .expect(201);
 
-      const freshAgentSlug = body<{ agent: { slug: string } }>(freshAgentRes).agent.slug;
+    const freshAgentSlug = body<{ agent: { slug: string } }>(freshAgentRes).agent.slug;
 
-      // Use a project that has no VERIFIED unassigned tickets for this new agent
-      // The simplest way: use a non-existent project slug → service returns null (or 404 for project)
-      // Per story spec: null when no candidates, so we verify this path via response
-      const res = await request(httpServer)
-        .get(`/api/agents/${freshAgentSlug}/pickup`)
-        .query({ project: projectSlug })
-        .set('Authorization', `Bearer ${userAccessToken}`)
-        .expect(200);
+    // Use a project that has no VERIFIED unassigned tickets for this new agent
+    // The simplest way: use a non-existent project slug → service returns null (or 404 for project)
+    // Per story spec: null when no candidates, so we verify this path via response
+    const res = await request(httpServer)
+      .get(`/api/agents/${freshAgentSlug}/pickup`)
+      .query({ project: projectSlug })
+      .set('Authorization', `Bearer ${userAccessToken}`)
+      .expect(200);
 
-      // All VERIFIED tickets in this project were already consumed or may still exist
-      // The key assertion: data is either a result or null — never an error for valid params
-      const { body: responseBody } = res;
-      expect(responseBody).toHaveProperty('ret', 0);
-      expect(responseBody).toHaveProperty('data');
-    });
+    // All VERIFIED tickets in this project were already consumed or may still exist
+    // The key assertion: data is either a result or null — never an error for valid params
+    const { body: responseBody } = res;
+    expect(responseBody).toHaveProperty('ret', 0);
+    expect(responseBody).toHaveProperty('data');
   });
 
   // ─────────────────────────────────────────────────────────────────

--- a/apps/web/pages/[project]/agents.vue
+++ b/apps/web/pages/[project]/agents.vue
@@ -31,7 +31,7 @@ function statusClass(status: string) {
 
 async function changeStatus(agent: Agent, newStatus: 'ACTIVE' | 'PAUSED' | 'OFFLINE') {
   try {
-    await $api.patch(`/projects/${slug}/agents/${agent.id}`, { status: newStatus })
+    await $api.patch(`/projects/${slug}/agents/${agent.slug}`, { status: newStatus })
     toast.success(t('agents.toast.statusUpdated', { status: newStatus }))
     refresh()
   } catch {

--- a/openapi.json
+++ b/openapi.json
@@ -1610,6 +1610,100 @@
         ]
       }
     },
+    "/api/projects/{slug}/agents": {
+      "get": {
+        "operationId": "ProjectsController_getProjectAgents",
+        "parameters": [
+          {
+            "name": "slug",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Agents retrieved successfully"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden - no project access"
+          },
+          "404": {
+            "description": "Project not found"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "List agents active in a project (derived from assigned tickets)",
+        "tags": [
+          "projects"
+        ]
+      }
+    },
+    "/api/projects/{slug}/agents/{agentSlug}": {
+      "patch": {
+        "operationId": "ProjectsController_updateProjectAgent",
+        "parameters": [
+          {
+            "name": "slug",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "agentSlug",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateAgentDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Agent updated successfully"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden - no project access"
+          },
+          "404": {
+            "description": "Project or agent not found"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Update an agent status within a project context (admin or project member)",
+        "tags": [
+          "projects"
+        ]
+      }
+    },
     "/api/projects/{slug}/tickets": {
       "post": {
         "operationId": "TicketsController_create",


### PR DESCRIPTION
## Summary

- **Root cause**: The web `/:project/agents` page called `GET /projects/:slug/agents` and `PATCH /projects/:slug/agents/:agentId` which did not exist in the NestJS API. The PATCH URL also used `agent.id` (Prisma cuid) instead of `agent.slug`.
- **Approach**: Agent has no direct `projectId` field — agents relate to projects only via `Ticket.assignedToAgentId`. The new repository method derives "project agents" from tickets with assigned agents in the target project (excluding soft-deleted tickets).
- **Auth**: Both routes check `checkProjectMembership` (admin and agent-principal bypass inherited). PATCH additionally verifies the target agent is scoped to the project (returns 404 if not).

## Changes

| Area | Change |
|------|--------|
| `PrismaAgentRepository` | `findByProjectSlug(slug)` — two-query pattern: project lookup then `agent.findMany` via `assignedTickets.some` |
| `AgentsService` | `findByProject(slug)` — wraps repo, throws `NotFoundAppException` on missing project |
| `ProjectsController` | `GET :slug/agents` and `PATCH :slug/agents/:agentSlug` routes; `AgentsModule` added to `ProjectsModule` imports |
| `apps/web/pages/[project]/agents.vue` | `agent.id` → `agent.slug` in PATCH URL |
| `openapi.json` + `apps/cli/src/generated/` | Regenerated to reflect new contract |
| Tests | Unit tests for repo/service/controller; `projects.module.spec.ts` DI wiring test; 6 e2e tests (GET 200/401/404, PATCH 200/403/404) |

## Test plan

- [ ] `bun run test` — 1948 tests pass (unit + e2e)
- [ ] `GET /api/projects/:slug/agents` returns agents with assigned tickets in the project
- [ ] `GET /api/projects/:slug/agents` returns 401 without auth, 404 for unknown project
- [ ] `PATCH /api/projects/:slug/agents/:agentSlug` updates agent status for members/admins
- [ ] `PATCH` returns 403 for non-members, 404 for agents not in the project
- [ ] Web `/:project/agents` page loads and status toggle works correctly
- [ ] OpenAPI spec includes both new paths with correct security/response schemas
- [ ] CLI generated client includes `projectsControllerGetProjectAgents` and `projectsControllerUpdateProjectAgent`

Closes #98