### PR TITLE
refactor: migrate all config access to typed DI token injection

### DIFF
--- a/apps/api/src/agents/agents.service.spec.ts
+++ b/apps/api/src/agents/agents.service.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AgentsService, CreateAgentDto as _CreateAgentDto } from './agents.service';
 import { PrismaAgentRepository } from './prisma-agent.repository';
-import { ConfigService } from '@nestjs/config';
+import { AUTH_CFG, IAuthConfig } from '../config/auth.config';
 import { NotFoundAppException, ValidationAppException } from '@nathapp/nestjs-common';
 import { createHmac } from 'crypto';
 import { randomBytes } from 'crypto';
@@ -73,8 +73,12 @@ describe('AgentsService', () => {
     findByProjectSlug: jest.fn(),
   };
 
-  const mockConfigService = {
-    get: jest.fn(),
+  const mockAuthConfig: IAuthConfig = {
+    jwtSecret: 'jwt-secret',
+    jwtExpiresIn: '15m',
+    jwtRefreshSecret: 'jwt-refresh-secret',
+    jwtRefreshExpiresIn: '7d',
+    apiKeySecret: 'test-secret',
   };
 
   const mockKodaDomainWriter = {
@@ -86,7 +90,7 @@ describe('AgentsService', () => {
       providers: [
         AgentsService,
         { provide: PrismaAgentRepository, useValue: mockAgentRepo },
-        { provide: ConfigService, useValue: mockConfigService },
+        { provide: AUTH_CFG, useValue: mockAuthConfig },
         { provide: KodaDomainWriter, useValue: mockKodaDomainWriter },
       ],
     }).compile();
@@ -95,12 +99,6 @@ describe('AgentsService', () => {
     agentRepo = module.get(PrismaAgentRepository);
     kodaDomainWriter = module.get(KodaDomainWriter);
 
-    mockConfigService.get.mockImplementation((key: string) => {
-      if (key === 'auth') {
-        return { apiKeySecret: 'test-secret' };
-      }
-      return null;
-    });
     mockAgentRepo.createRolesAndCapabilities.mockResolvedValue(undefined);
 
     mockAgentRepo.replaceRoles.mockResolvedValue(undefined);
@@ -115,7 +113,6 @@ describe('AgentsService', () => {
     describe('for new agent creation', () => {
       it('should generate random 32-byte hex key', async () => {
         mockAgentRepo.create.mockResolvedValue(mockAgent);
-        mockConfigService.get.mockReturnValue({ apiKeySecret: 'test-secret' });
 
         const result = await service.generateApiKey({
           name: 'Test Agent',
@@ -131,7 +128,6 @@ describe('AgentsService', () => {
 
       it('should compute HMAC-SHA256 hash with API_KEY_SECRET', async () => {
         mockAgentRepo.create.mockResolvedValue(mockAgent);
-        mockConfigService.get.mockReturnValue({ apiKeySecret: 'test-secret' });
 
         const result = await service.generateApiKey({
           name: 'Test Agent',
@@ -148,7 +144,6 @@ describe('AgentsService', () => {
 
       it('should return raw key ONCE to client (not stored)', async () => {
         mockAgentRepo.create.mockResolvedValue(mockAgent);
-        mockConfigService.get.mockReturnValue({ apiKeySecret: 'test-secret' });
 
         const result = await service.generateApiKey({
           name: 'Test Agent',
@@ -163,7 +158,6 @@ describe('AgentsService', () => {
 
       it('should store only hash in database', async () => {
         mockAgentRepo.create.mockResolvedValue(mockAgent);
-        mockConfigService.get.mockReturnValue({ apiKeySecret: 'test-secret' });
 
         const result = await service.generateApiKey({
           name: 'Test Agent',
@@ -180,7 +174,6 @@ describe('AgentsService', () => {
 
       it('should include agent name and slug in creation', async () => {
         mockAgentRepo.create.mockResolvedValue(mockAgent);
-        mockConfigService.get.mockReturnValue({ apiKeySecret: 'test-secret' });
 
         await service.generateApiKey({
           name: 'Test Agent',
@@ -195,9 +188,7 @@ describe('AgentsService', () => {
       });
 
       it('should use correct API_KEY_SECRET from config', async () => {
-        const secret = 'my-custom-secret';
         mockAgentRepo.create.mockResolvedValue(mockAgent);
-        mockConfigService.get.mockReturnValue({ apiKeySecret: secret });
 
         const result = await service.generateApiKey({
           name: 'Test Agent',
@@ -205,16 +196,26 @@ describe('AgentsService', () => {
           roles: ['DEVELOPER'],
         });
 
-        const expectedHash = createHmac('sha256', secret).update(result.apiKey).digest('hex');
+        const expectedHash = createHmac('sha256', 'test-secret').update(result.apiKey).digest('hex');
 
         const createCall = (agentRepo.create as jest.Mock).mock.calls[0][0];
         expect(createCall.apiKeyHash).toBe(expectedHash);
       });
 
       it('should throw error when API_KEY_SECRET is not configured', async () => {
-        mockConfigService.get.mockReturnValue({});
+        // Mock auth config without apiKeySecret
+        const moduleWithoutSecret: TestingModule = await Test.createTestingModule({
+          providers: [
+            AgentsService,
+            { provide: PrismaAgentRepository, useValue: mockAgentRepo },
+            { provide: AUTH_CFG, useValue: { ...mockAuthConfig, apiKeySecret: undefined } },
+            { provide: KodaDomainWriter, useValue: mockKodaDomainWriter },
+          ],
+        }).compile();
 
-        await expect(service.generateApiKey({
+        const serviceWithoutSecret = moduleWithoutSecret.get<AgentsService>(AgentsService);
+
+        await expect(serviceWithoutSecret.generateApiKey({
           name: 'Test Agent',
           slug: 'test-agent',
           roles: ['DEVELOPER'],
@@ -222,8 +223,6 @@ describe('AgentsService', () => {
       });
 
       it('should reject invalid roles before creating the agent', async () => {
-        mockConfigService.get.mockReturnValue({ apiKeySecret: 'test-secret' });
-
         await expect(service.generateApiKey({
           name: 'Test Agent',
           slug: 'test-agent',
@@ -235,7 +234,6 @@ describe('AgentsService', () => {
 
       it('should return created agent in response', async () => {
         mockAgentRepo.create.mockResolvedValue(mockAgent);
-        mockConfigService.get.mockReturnValue({ apiKeySecret: 'test-secret' });
 
         const result = await service.generateApiKey({
           name: 'Test Agent',
@@ -256,7 +254,6 @@ describe('AgentsService', () => {
       it('should generate new random API key', async () => {
         mockAgentRepo.updateApiKeyHash.mockResolvedValue(mockAgent);
         mockAgentRepo.findBySlugScalar.mockResolvedValue(mockAgentWithRelations);
-        mockConfigService.get.mockReturnValue({ apiKeySecret: 'test-secret' });
 
         const result = await service.generateApiKey('agent-123');
 
@@ -270,7 +267,6 @@ describe('AgentsService', () => {
 
         mockAgentRepo.updateApiKeyHash.mockResolvedValue(agentWithOldHash);
         mockAgentRepo.findBySlugScalar.mockResolvedValue(mockAgentWithRelations);
-        mockConfigService.get.mockReturnValue({ apiKeySecret: 'test-secret' });
 
         const result = await service.generateApiKey('agent-123');
 
@@ -289,7 +285,6 @@ describe('AgentsService', () => {
         const agentWithOldKey = { ...mockAgent, apiKeyHash: oldHash };
         mockAgentRepo.updateApiKeyHash.mockResolvedValue(agentWithOldKey);
         mockAgentRepo.findBySlugScalar.mockResolvedValue(mockAgentWithRelations);
-        mockConfigService.get.mockReturnValue({ apiKeySecret: 'test-secret' });
 
         const result = await service.generateApiKey('agent-123');
 
@@ -301,7 +296,6 @@ describe('AgentsService', () => {
       it('should return new raw key ONCE', async () => {
         mockAgentRepo.updateApiKeyHash.mockResolvedValue(mockAgent);
         mockAgentRepo.findBySlugScalar.mockResolvedValue(mockAgentWithRelations);
-        mockConfigService.get.mockReturnValue({ apiKeySecret: 'test-secret' });
 
         const result = await service.generateApiKey('agent-123');
 
@@ -627,7 +621,6 @@ describe('AgentsService', () => {
     it('should generate new API key for agent', async () => {
       mockAgentRepo.updateApiKeyHash.mockResolvedValue(mockAgent);
       mockAgentRepo.findBySlugScalar.mockResolvedValue(mockAgent);
-      mockConfigService.get.mockReturnValue({ apiKeySecret: 'test-secret' });
 
       const result = await service.rotateApiKey('test-agent');
 
@@ -640,7 +633,6 @@ describe('AgentsService', () => {
 
       mockAgentRepo.updateApiKeyHash.mockResolvedValue(agentWithOldHash);
       mockAgentRepo.findBySlugScalar.mockResolvedValue(mockAgent);
-      mockConfigService.get.mockReturnValue({ apiKeySecret: 'test-secret' });
 
       const result = await service.rotateApiKey('test-agent');
 
@@ -651,7 +643,6 @@ describe('AgentsService', () => {
     it('should return raw key ONCE', async () => {
       mockAgentRepo.updateApiKeyHash.mockResolvedValue(mockAgent);
       mockAgentRepo.findBySlugScalar.mockResolvedValue(mockAgent);
-      mockConfigService.get.mockReturnValue({ apiKeySecret: 'test-secret' });
 
       const result = await service.rotateApiKey('test-agent');
 
@@ -661,7 +652,6 @@ describe('AgentsService', () => {
 
     it('should throw error when agent not found', async () => {
       mockAgentRepo.findBySlugScalar.mockResolvedValue(null);
-      mockConfigService.get.mockReturnValue({ apiKeySecret: 'test-secret' });
 
       await expect(service.rotateApiKey('nonexistent')).rejects.toThrow();
     });
@@ -820,7 +810,6 @@ describe('AgentsService', () => {
   describe('API Key Validation', () => {
     it('should generate unique API keys on multiple calls', async () => {
       mockAgentRepo.create.mockResolvedValue(mockAgent);
-      mockConfigService.get.mockReturnValue({ apiKeySecret: 'test-secret' });
 
       const result1 = await service.generateApiKey({
         name: 'Agent 1',

--- a/apps/api/src/agents/agents.service.ts
+++ b/apps/api/src/agents/agents.service.ts
@@ -1,5 +1,4 @@
-import { Injectable, Optional } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
+import { Injectable, Optional, Inject } from '@nestjs/common';
 import { IsString, IsOptional, IsNumber, IsArray, IsIn, MinLength, ArrayMinSize } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 import { NotFoundAppException, ValidationAppException } from '@nathapp/nestjs-common';
@@ -10,6 +9,7 @@ import { TicketResponseDto } from '../tickets/dto/ticket-response.dto';
 import { KodaDomainWriter } from '../koda-domain-writer/koda-domain-writer.service';
 import { AgentAuthProvider } from '../auth/agent-auth.provider';
 import { PrismaAgentRepository } from './prisma-agent.repository';
+import { AUTH_CFG, IAuthConfig } from '../config/auth.config';
 
 export class CreateAgentDto {
   @ApiProperty({ example: 'Subrina Coder' })
@@ -78,7 +78,7 @@ export class UpdateCapabilitiesDto {
 export class AgentsService {
   constructor(
     private readonly agentRepo: PrismaAgentRepository,
-    private configService: ConfigService,
+    @Inject(AUTH_CFG) private readonly authConfig: IAuthConfig,
     @Optional() private readonly kodaDomainWriter?: KodaDomainWriter,
     @Optional() private readonly agentAuthProvider?: AgentAuthProvider,
   ) {}
@@ -124,8 +124,7 @@ export class AgentsService {
     const rawKey = randomBytes(32).toString('hex');
 
     // Compute HMAC-SHA256 hash with API_KEY_SECRET
-    const authCfg = this.configService.get<{ apiKeySecret?: string }>('auth');
-    const apiKeySecret = authCfg?.apiKeySecret;
+    const apiKeySecret = this.authConfig.apiKeySecret;
     if (!apiKeySecret) {
       throw new ValidationAppException();
     }

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -27,13 +27,13 @@ import { EntityGraphModule } from './entity-graph/entity-graph.module';
 import { ContextModule } from './context/context.module';
 import { PolicyModule } from './policy/policy.module';
 import { MonitoringModule } from './monitoring/monitoring.module';
-import { APP_CFG, IAppConfig, appConfig } from './config/app.config';
-import { AUTH_CFG, IAuthConfig, authConfig } from './config/auth.config';
+import { appConfig } from './config/app.config';
+import { authConfig } from './config/auth.config';
 import { databaseConfig } from './config/database.config';
-import { RAG_CFG, IRagConfig, ragConfig } from './config/rag.config';
-import { VCS_CFG, IVcsConfig, vcsConfig } from './config/vcs.config';
+import { ragConfig } from './config/rag.config';
+import { vcsConfig } from './config/vcs.config';
 import { validate } from './config/env.validation';
-import { ConfigService } from '@nestjs/config';
+import { ConfigBridgeModule } from './config/config-bridge.module';
 
 @Module({
   imports: [
@@ -43,12 +43,13 @@ import { ConfigService } from '@nestjs/config';
       load: [appConfig, authConfig, databaseConfig, ragConfig, vcsConfig],
       validate: validate,
     }),
+    ConfigBridgeModule,
     I18nCoreModule.forRoot({
       fallbackLanguage: 'en',
       loaderOptions: {
         path: join(__dirname, 'i18n'),
         watch: false,
-      },      
+      },
     }),
     LoggingModule.register({}),
     PrismaModule.forRoot({
@@ -90,12 +91,5 @@ import { ConfigService } from '@nestjs/config';
     PolicyModule,
     MonitoringModule,
   ],
-  providers: [
-    { provide: APP_CFG,  useFactory: (cs: ConfigService) => cs.get<IAppConfig>('app'),  inject: [ConfigService] },
-    { provide: AUTH_CFG, useFactory: (cs: ConfigService) => cs.get<IAuthConfig>('auth'), inject: [ConfigService] },
-    { provide: RAG_CFG,  useFactory: (cs: ConfigService) => cs.get<IRagConfig>('rag'),   inject: [ConfigService] },
-    { provide: VCS_CFG,  useFactory: (cs: ConfigService) => cs.get<IVcsConfig>('vcs'),   inject: [ConfigService] },
-  ],
-  exports: [APP_CFG, AUTH_CFG, RAG_CFG, VCS_CFG],
 })
 export class AppModule {}

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -27,12 +27,13 @@ import { EntityGraphModule } from './entity-graph/entity-graph.module';
 import { ContextModule } from './context/context.module';
 import { PolicyModule } from './policy/policy.module';
 import { MonitoringModule } from './monitoring/monitoring.module';
-import { appConfig } from './config/app.config';
-import { authConfig } from './config/auth.config';
+import { APP_CFG, IAppConfig, appConfig } from './config/app.config';
+import { AUTH_CFG, IAuthConfig, authConfig } from './config/auth.config';
 import { databaseConfig } from './config/database.config';
-import { ragConfig } from './config/rag.config';
-import { vcsConfig } from './config/vcs.config';
+import { RAG_CFG, IRagConfig, ragConfig } from './config/rag.config';
+import { VCS_CFG, IVcsConfig, vcsConfig } from './config/vcs.config';
 import { validate } from './config/env.validation';
+import { ConfigService } from '@nestjs/config';
 
 @Module({
   imports: [
@@ -89,5 +90,12 @@ import { validate } from './config/env.validation';
     PolicyModule,
     MonitoringModule,
   ],
+  providers: [
+    { provide: APP_CFG,  useFactory: (cs: ConfigService) => cs.get<IAppConfig>('app'),  inject: [ConfigService] },
+    { provide: AUTH_CFG, useFactory: (cs: ConfigService) => cs.get<IAuthConfig>('auth'), inject: [ConfigService] },
+    { provide: RAG_CFG,  useFactory: (cs: ConfigService) => cs.get<IRagConfig>('rag'),   inject: [ConfigService] },
+    { provide: VCS_CFG,  useFactory: (cs: ConfigService) => cs.get<IVcsConfig>('vcs'),   inject: [ConfigService] },
+  ],
+  exports: [APP_CFG, AUTH_CFG, RAG_CFG, VCS_CFG],
 })
 export class AppModule {}

--- a/apps/api/src/auth/guards/combined-auth.guard.spec.ts
+++ b/apps/api/src/auth/guards/combined-auth.guard.spec.ts
@@ -1,7 +1,7 @@
 import { ExecutionContext } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
-import { ConfigService } from '@nestjs/config';
 import { IS_PUBLIC_KEY } from '@nathapp/nestjs-auth';
+import { AUTH_CFG, IAuthConfig } from '../../config/auth.config';
 import { CombinedAuthGuard } from './combined-auth.guard';
 import type { PrismaService } from '@nathapp/nestjs-prisma';
 import type { AgentAuthProvider } from '../agent-auth.provider';
@@ -22,10 +22,14 @@ function makePrisma(agent: unknown = null): jest.Mocked<PrismaService> {
   } as unknown as jest.Mocked<PrismaService>;
 }
 
-function makeConfig(apiKeySecret = 'super-secret'): jest.Mocked<ConfigService> {
+function makeConfig(apiKeySecret: string | undefined = 'super-secret'): IAuthConfig {
   return {
-    get: jest.fn().mockReturnValue({ apiKeySecret }),
-  } as unknown as jest.Mocked<ConfigService>;
+    apiKeySecret,
+    jwtSecret: undefined,
+    jwtExpiresIn: '15m',
+    jwtRefreshSecret: undefined,
+    jwtRefreshExpiresIn: '7d',
+  };
 }
 
 function makeAgentAuthProvider(principal = { actorType: 'agent', id: 'agent-1' }): jest.Mocked<AgentAuthProvider> {
@@ -174,8 +178,7 @@ describe('CombinedAuthGuard', () => {
     });
 
     it('falls back to JWT when apiKeySecret is not configured', async () => {
-      const config = makeConfig(undefined as any);
-      config.get.mockReturnValue({ apiKeySecret: undefined });
+      const config = makeConfig(undefined);
       const prisma = makePrisma();
       const reflector = makeReflector(false);
       const guard = new CombinedAuthGuard(reflector, prisma, config, makeAgentAuthProvider());

--- a/apps/api/src/auth/guards/combined-auth.guard.ts
+++ b/apps/api/src/auth/guards/combined-auth.guard.ts
@@ -1,11 +1,11 @@
-import { ExecutionContext, Injectable, Logger } from '@nestjs/common';
+import { ExecutionContext, Inject, Injectable, Logger } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
-import { ConfigService } from '@nestjs/config';
 import { IS_PUBLIC_KEY, JwtAuthGuard } from '@nathapp/nestjs-auth';
 import { PrismaService } from '@nathapp/nestjs-prisma';
 import { PrismaClient } from '@prisma/client';
 import { createHmac } from 'crypto';
 import { AgentAuthProvider } from '../agent-auth.provider';
+import { AUTH_CFG, IAuthConfig } from '../../config/auth.config';
 
 @Injectable()
 export class CombinedAuthGuard extends JwtAuthGuard {
@@ -14,7 +14,7 @@ export class CombinedAuthGuard extends JwtAuthGuard {
   constructor(
     private readonly myReflector: Reflector,
     private readonly prisma: PrismaService,
-    private readonly config: ConfigService,
+    @Inject(AUTH_CFG) private readonly authConfig: IAuthConfig,
     private readonly agentAuthProvider: AgentAuthProvider,
   ) {
     super(myReflector);
@@ -73,8 +73,7 @@ export class CombinedAuthGuard extends JwtAuthGuard {
     // JWTs always have exactly 3 dot-separated parts; skip them
     if (rawKey.split('.').length === 3) return false;
 
-    const authCfg = this.config.get<{ apiKeySecret?: string }>('auth');
-    const secret = authCfg?.apiKeySecret;
+    const secret = this.authConfig.apiKeySecret;
     if (!secret) {
       this.combinedLogger.error('auth.apiKeySecret not configured');
       return false;

--- a/apps/api/src/code-intel/code-commit-outbox-handler.spec.ts
+++ b/apps/api/src/code-intel/code-commit-outbox-handler.spec.ts
@@ -1,8 +1,8 @@
 import { CodeCommitOutboxHandler } from './code-commit-outbox-handler';
 import { AstIndexService } from './ast-index.service';
 import { PrismaService } from '@nathapp/nestjs-prisma';
-import { ConfigService } from '@nestjs/config';
 import { IVcsProvider } from '../vcs/vcs-provider';
+import { IVcsConfig } from '../config/vcs.config';
 import { SourceFile } from '../vcs/types';
 
 jest.mock('../common/utils/encryption.util', () => ({
@@ -46,8 +46,12 @@ function createMockAstIndexService() {
   return { indexCommit: jest.fn().mockResolvedValue(undefined) } as unknown as jest.Mocked<AstIndexService>;
 }
 
-function createMockConfigService(encryptionKey?: string) {
-  return { get: jest.fn().mockReturnValue(encryptionKey) } as unknown as ConfigService;
+function createMockVcsConfig(encryptionKey?: string): IVcsConfig {
+  return {
+    encryptionKey,
+    defaultPollingIntervalMs: 600000,
+    githubApiUrl: 'https://api.github.com',
+  };
 }
 
 const defaultConnection = {
@@ -128,7 +132,7 @@ describe('CodeCommitOutboxHandler', () => {
       handler = new CodeCommitOutboxHandler(
         createMockPrismaService(null),
         createMockAstIndexService(),
-        createMockConfigService('enc-key'),
+        createMockVcsConfig('enc-key'),
       );
 
       await handler.process({
@@ -147,7 +151,7 @@ describe('CodeCommitOutboxHandler', () => {
       handler = new CodeCommitOutboxHandler(
         createMockPrismaService(defaultConnection),
         createMockAstIndexService(),
-        createMockConfigService(undefined),
+        createMockVcsConfig(undefined),
       );
 
       await handler.process({
@@ -169,7 +173,7 @@ describe('CodeCommitOutboxHandler', () => {
       handler = new CodeCommitOutboxHandler(
         createMockPrismaService(defaultConnection),
         createMockAstIndexService(),
-        createMockConfigService('enc-key'),
+        createMockVcsConfig('enc-key'),
       );
 
       await handler.process({
@@ -193,7 +197,7 @@ describe('CodeCommitOutboxHandler', () => {
       handler = new CodeCommitOutboxHandler(
         createMockPrismaService(defaultConnection),
         createMockAstIndexService(),
-        createMockConfigService('enc-key'),
+        createMockVcsConfig('enc-key'),
       );
 
       await expect(handler.process({
@@ -218,7 +222,7 @@ describe('CodeCommitOutboxHandler', () => {
       handler = new CodeCommitOutboxHandler(
         createMockPrismaService(defaultConnection),
         mockAstIndex,
-        createMockConfigService('enc-key'),
+        createMockVcsConfig('enc-key'),
       );
 
       await handler.process({

--- a/apps/api/src/code-intel/code-commit-outbox-handler.ts
+++ b/apps/api/src/code-intel/code-commit-outbox-handler.ts
@@ -1,8 +1,8 @@
 import { Injectable, Logger, Inject, Optional } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
 import { PrismaService } from '@nathapp/nestjs-prisma';
 import { AstIndexService, SourceFile } from './ast-index.service';
 import { createVcsProvider } from '../vcs/factory';
+import { VCS_CFG, IVcsConfig } from '../config/vcs.config';
 import type { VcsProviderConfig } from '../vcs/factory';
 
 interface CodeCommitPayload {
@@ -30,7 +30,7 @@ export class CodeCommitOutboxHandler {
   constructor(
     private readonly prisma: PrismaService,
     private readonly astIndexService: AstIndexService,
-    @Optional() @Inject(ConfigService) private readonly configService?: ConfigService,
+    @Optional() @Inject(VCS_CFG) private readonly vcsConfig?: IVcsConfig,
   ) {}
 
   private get db() {
@@ -53,7 +53,7 @@ export class CodeCommitOutboxHandler {
       return;
     }
 
-    const encryptionKey = this.configService?.get<string>('vcs.encryptionKey');
+    const encryptionKey = this.vcsConfig?.encryptionKey;
     if (!encryptionKey) {
       this.logger.error(`code_commit: VCS encryption key not configured`);
       return;

--- a/apps/api/src/common/test-helpers/global-stubs.module.ts
+++ b/apps/api/src/common/test-helpers/global-stubs.module.ts
@@ -6,6 +6,7 @@ import { CacheManager } from '@nathapp/nestjs-cache';
 import { PrismaProjectRepository } from '../../projects/prisma-project.repository';
 import { AgentsService } from '../../agents/agents.service';
 import { authConfig } from '../../config/auth.config';
+import { vcsConfig } from '../../config/vcs.config';
 
 export const mockPrismaService = {
   client: {},
@@ -36,7 +37,7 @@ export const mockCacheManager = {
     // real ConfigService that can resolve the JWT config object structure.
     ConfigModule.forRoot({
       isGlobal: true,
-      load: [authConfig],
+      load: [authConfig, vcsConfig],
       envFilePath: ['.env.test'],
     }),
   ],

--- a/apps/api/src/common/test-helpers/global-stubs.module.ts
+++ b/apps/api/src/common/test-helpers/global-stubs.module.ts
@@ -5,8 +5,9 @@ import { ITransactionManager, TRANSACTION_MANAGER } from '@nathapp/nestjs-data';
 import { CacheManager } from '@nathapp/nestjs-cache';
 import { PrismaProjectRepository } from '../../projects/prisma-project.repository';
 import { AgentsService } from '../../agents/agents.service';
-import { authConfig } from '../../config/auth.config';
-import { vcsConfig } from '../../config/vcs.config';
+import { AUTH_CFG, IAuthConfig, authConfig } from '../../config/auth.config';
+import { RAG_CFG, IRagConfig } from '../../config/rag.config';
+import { VCS_CFG, IVcsConfig, vcsConfig } from '../../config/vcs.config';
 
 export const mockPrismaService = {
   client: {},
@@ -29,6 +30,37 @@ export const mockCacheManager = {
   del: async () => undefined,
 } as unknown as CacheManager;
 
+export const mockAuthConfig: IAuthConfig = {
+  jwtSecret: 'test-secret',
+  jwtExpiresIn: '15m',
+  jwtRefreshSecret: 'test-refresh-secret',
+  jwtRefreshExpiresIn: '7d',
+  apiKeySecret: 'test-api-key-secret',
+};
+
+export const mockRagConfig: IRagConfig = {
+  embeddingProvider: 'ollama',
+  embeddingModel: 'nomic-embed-text',
+  ollamaBaseUrl: 'http://localhost:11434',
+  openaiApiKey: undefined,
+  lancedbPath: '/tmp/lancedb-test',
+  inMemoryOnly: true,
+  ftsIndexMode: 'disk',
+  similarityHigh: 0.85,
+  similarityMedium: 0.7,
+  similarityLow: 0.5,
+  ftsOptimizeStrategy: 'counter',
+  ftsOptimizeThreshold: 100,
+  ftsOptimizeIntervalMs: 60000,
+  graphifyEnabledCacheTtlSec: 60,
+};
+
+export const mockVcsConfig: IVcsConfig = {
+  encryptionKey: undefined,
+  defaultPollingIntervalMs: 300000,
+  githubApiUrl: 'https://api.github.com',
+};
+
 @Global()
 @Module({
   imports: [
@@ -47,7 +79,10 @@ export const mockCacheManager = {
     PrismaProjectRepository,
     { provide: AgentsService, useValue: mockAgentsService },
     { provide: CacheManager, useValue: mockCacheManager },
+    { provide: AUTH_CFG, useValue: mockAuthConfig },
+    { provide: RAG_CFG, useValue: mockRagConfig },
+    { provide: VCS_CFG, useValue: mockVcsConfig },
   ],
-  exports: [PrismaService, TRANSACTION_MANAGER, ConfigModule, PrismaProjectRepository, AgentsService, CacheManager],
+  exports: [PrismaService, TRANSACTION_MANAGER, ConfigModule, PrismaProjectRepository, AgentsService, CacheManager, AUTH_CFG, RAG_CFG, VCS_CFG],
 })
 export class GlobalStubsModule {}

--- a/apps/api/src/common/test-helpers/global-stubs.module.ts
+++ b/apps/api/src/common/test-helpers/global-stubs.module.ts
@@ -42,7 +42,7 @@ export const mockRagConfig: IRagConfig = {
   embeddingProvider: 'ollama',
   embeddingModel: 'nomic-embed-text',
   ollamaBaseUrl: 'http://localhost:11434',
-  openaiApiKey: undefined,
+  openaiApiKey: '',
   lancedbPath: '/tmp/lancedb-test',
   inMemoryOnly: true,
   ftsIndexMode: 'disk',

--- a/apps/api/src/config/app.config.spec.ts
+++ b/apps/api/src/config/app.config.spec.ts
@@ -1,3 +1,4 @@
+/// <reference types="jest" />
 import { appConfig, IAppConfig } from './app.config';
 
 describe('appConfig', () => {

--- a/apps/api/src/config/app.config.spec.ts
+++ b/apps/api/src/config/app.config.spec.ts
@@ -1,0 +1,24 @@
+import { appConfig, IAppConfig } from './app.config';
+
+describe('appConfig', () => {
+  beforeEach(() => {
+    delete process.env['API_PORT'];
+    delete process.env['API_HOST'];
+    delete process.env['NODE_ENV'];
+    delete process.env['GLOBAL_PREFIX'];
+  });
+
+  it('returns typed IAppConfig with defaults', () => {
+    const cfg: IAppConfig = appConfig();
+    expect(cfg.port).toBe(3100);
+    expect(cfg.host).toBe('0.0.0.0');
+    expect(cfg.nodeEnv).toBe('development');
+    expect(cfg.globalPrefix).toBe('api');
+  });
+
+  it('reads API_HOST from env', () => {
+    process.env['API_HOST'] = '127.0.0.1';
+    const cfg: IAppConfig = appConfig();
+    expect(cfg.host).toBe('127.0.0.1');
+  });
+});

--- a/apps/api/src/config/app.config.ts
+++ b/apps/api/src/config/app.config.ts
@@ -1,7 +1,40 @@
+import { validateUtil } from '@nathapp/nestjs-common';
 import { registerAs } from '@nestjs/config';
+import { IsNumber, IsOptional, IsString } from 'class-validator';
 
-export const appConfig = registerAs('app', () => ({
-  port: parseInt(process.env['API_PORT'] ?? '3100', 10),
-  nodeEnv: process.env['NODE_ENV'] ?? 'development',
-  globalPrefix: process.env['GLOBAL_PREFIX'] ?? 'api',
-}));
+export const APP_CFG = 'app';
+
+export interface IAppConfig {
+  port: number;
+  host: string;
+  nodeEnv: string;
+  globalPrefix: string;
+}
+
+export class AppConfigSchema {
+  @IsOptional()
+  @IsNumber()
+  API_PORT: number;
+
+  @IsOptional()
+  @IsString()
+  API_HOST: string;
+
+  @IsOptional()
+  @IsString()
+  NODE_ENV: string;
+
+  @IsOptional()
+  @IsString()
+  GLOBAL_PREFIX: string;
+}
+
+export const appConfig = registerAs(APP_CFG, (): IAppConfig => {
+  validateUtil(process.env, AppConfigSchema);
+  return {
+    port: parseInt(process.env['API_PORT'] ?? '3100', 10),
+    host: process.env['API_HOST'] ?? '0.0.0.0',
+    nodeEnv: process.env['NODE_ENV'] ?? 'development',
+    globalPrefix: process.env['GLOBAL_PREFIX'] ?? 'api',
+  };
+});

--- a/apps/api/src/config/auth.config.spec.ts
+++ b/apps/api/src/config/auth.config.spec.ts
@@ -1,6 +1,6 @@
 /// <reference types="jest" />
 
-import { authConfig } from './auth.config';
+import { IAuthConfig, authConfig } from './auth.config';
 
 describe('authConfig defaults', () => {
   it('uses hardened defaults when expiry env vars are unset', () => {
@@ -53,5 +53,17 @@ describe('authConfig defaults', () => {
         delete process.env['JWT_REFRESH_EXPIRES_IN'];
       }
     }
+  });
+
+  it('returns typed IAuthConfig', () => {
+    process.env['JWT_SECRET'] = 'test-secret';
+    process.env['JWT_REFRESH_SECRET'] = 'test-refresh-secret';
+    process.env['API_KEY_SECRET'] = 'test-api-key-secret';
+    const cfg: IAuthConfig = authConfig();
+    expect(cfg.jwtSecret).toBe('test-secret');
+    expect(cfg.apiKeySecret).toBe('test-api-key-secret');
+    delete process.env['JWT_SECRET'];
+    delete process.env['JWT_REFRESH_SECRET'];
+    delete process.env['API_KEY_SECRET'];
   });
 });

--- a/apps/api/src/config/auth.config.ts
+++ b/apps/api/src/config/auth.config.ts
@@ -5,9 +5,9 @@ import { IsOptional, IsString } from 'class-validator';
 export const AUTH_CFG = 'auth';
 
 export interface IAuthConfig {
-  jwtSecret: string | undefined;
+  jwtSecret: string;
   jwtExpiresIn: string;
-  jwtRefreshSecret: string | undefined;
+  jwtRefreshSecret: string;
   jwtRefreshExpiresIn: string;
   apiKeySecret: string | undefined;
 }

--- a/apps/api/src/config/auth.config.ts
+++ b/apps/api/src/config/auth.config.ts
@@ -34,9 +34,9 @@ export class AuthConfigSchema {
 export const authConfig = registerAs(AUTH_CFG, (): IAuthConfig => {
   validateUtil(process.env, AuthConfigSchema);
   return {
-    jwtSecret: process.env['JWT_SECRET']!,
+    jwtSecret: process.env['JWT_SECRET'] as string,
     jwtExpiresIn: process.env['JWT_EXPIRES_IN'] ?? '15m',
-    jwtRefreshSecret: process.env['JWT_REFRESH_SECRET']!,
+    jwtRefreshSecret: process.env['JWT_REFRESH_SECRET'] as string,
     jwtRefreshExpiresIn: process.env['JWT_REFRESH_EXPIRES_IN'] ?? '7d',
     apiKeySecret: process.env['API_KEY_SECRET'],
   };

--- a/apps/api/src/config/auth.config.ts
+++ b/apps/api/src/config/auth.config.ts
@@ -34,9 +34,9 @@ export class AuthConfigSchema {
 export const authConfig = registerAs(AUTH_CFG, (): IAuthConfig => {
   validateUtil(process.env, AuthConfigSchema);
   return {
-    jwtSecret: process.env['JWT_SECRET'],
+    jwtSecret: process.env['JWT_SECRET']!,
     jwtExpiresIn: process.env['JWT_EXPIRES_IN'] ?? '15m',
-    jwtRefreshSecret: process.env['JWT_REFRESH_SECRET'],
+    jwtRefreshSecret: process.env['JWT_REFRESH_SECRET']!,
     jwtRefreshExpiresIn: process.env['JWT_REFRESH_EXPIRES_IN'] ?? '7d',
     apiKeySecret: process.env['API_KEY_SECRET'],
   };

--- a/apps/api/src/config/auth.config.ts
+++ b/apps/api/src/config/auth.config.ts
@@ -1,9 +1,43 @@
+import { validateUtil } from '@nathapp/nestjs-common';
 import { registerAs } from '@nestjs/config';
+import { IsOptional, IsString } from 'class-validator';
 
-export const authConfig = registerAs('auth', () => ({
-  jwtSecret: process.env['JWT_SECRET'],
-  jwtExpiresIn: process.env['JWT_EXPIRES_IN'] ?? '15m',
-  jwtRefreshSecret: process.env['JWT_REFRESH_SECRET'],
-  jwtRefreshExpiresIn: process.env['JWT_REFRESH_EXPIRES_IN'] ?? '7d',
-  apiKeySecret: process.env['API_KEY_SECRET'],
-}));
+export const AUTH_CFG = 'auth';
+
+export interface IAuthConfig {
+  jwtSecret: string | undefined;
+  jwtExpiresIn: string;
+  jwtRefreshSecret: string | undefined;
+  jwtRefreshExpiresIn: string;
+  apiKeySecret: string | undefined;
+}
+
+export class AuthConfigSchema {
+  @IsString()
+  JWT_SECRET: string;
+
+  @IsOptional()
+  @IsString()
+  JWT_EXPIRES_IN: string;
+
+  @IsString()
+  JWT_REFRESH_SECRET: string;
+
+  @IsOptional()
+  @IsString()
+  JWT_REFRESH_EXPIRES_IN: string;
+
+  @IsString()
+  API_KEY_SECRET: string;
+}
+
+export const authConfig = registerAs(AUTH_CFG, (): IAuthConfig => {
+  validateUtil(process.env, AuthConfigSchema);
+  return {
+    jwtSecret: process.env['JWT_SECRET'],
+    jwtExpiresIn: process.env['JWT_EXPIRES_IN'] ?? '15m',
+    jwtRefreshSecret: process.env['JWT_REFRESH_SECRET'],
+    jwtRefreshExpiresIn: process.env['JWT_REFRESH_EXPIRES_IN'] ?? '7d',
+    apiKeySecret: process.env['API_KEY_SECRET'],
+  };
+});

--- a/apps/api/src/config/config-bridge.module.ts
+++ b/apps/api/src/config/config-bridge.module.ts
@@ -1,0 +1,18 @@
+import { Global, Module } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { APP_CFG, IAppConfig } from './app.config';
+import { AUTH_CFG, IAuthConfig } from './auth.config';
+import { RAG_CFG, IRagConfig } from './rag.config';
+import { VCS_CFG, IVcsConfig } from './vcs.config';
+
+@Global()
+@Module({
+  providers: [
+    { provide: APP_CFG,  useFactory: (cs: ConfigService) => cs.get<IAppConfig>('app'),   inject: [ConfigService] },
+    { provide: AUTH_CFG, useFactory: (cs: ConfigService) => cs.get<IAuthConfig>('auth'), inject: [ConfigService] },
+    { provide: RAG_CFG,  useFactory: (cs: ConfigService) => cs.get<IRagConfig>('rag'),   inject: [ConfigService] },
+    { provide: VCS_CFG,  useFactory: (cs: ConfigService) => cs.get<IVcsConfig>('vcs'),   inject: [ConfigService] },
+  ],
+  exports: [APP_CFG, AUTH_CFG, RAG_CFG, VCS_CFG],
+})
+export class ConfigBridgeModule {}

--- a/apps/api/src/config/config-bridge.module.ts
+++ b/apps/api/src/config/config-bridge.module.ts
@@ -8,10 +8,42 @@ import { VCS_CFG, IVcsConfig } from './vcs.config';
 @Global()
 @Module({
   providers: [
-    { provide: APP_CFG,  useFactory: (cs: ConfigService) => cs.get<IAppConfig>('app'),   inject: [ConfigService] },
-    { provide: AUTH_CFG, useFactory: (cs: ConfigService) => cs.get<IAuthConfig>('auth'), inject: [ConfigService] },
-    { provide: RAG_CFG,  useFactory: (cs: ConfigService) => cs.get<IRagConfig>('rag'),   inject: [ConfigService] },
-    { provide: VCS_CFG,  useFactory: (cs: ConfigService) => cs.get<IVcsConfig>('vcs'),   inject: [ConfigService] },
+    {
+      provide: APP_CFG,
+      useFactory: (cs: ConfigService) => {
+        const cfg = cs.get<IAppConfig>('app');
+        if (!cfg) throw new Error('ConfigBridgeModule: app config not loaded — ensure appConfig is in ConfigModule.forRoot load array');
+        return cfg;
+      },
+      inject: [ConfigService],
+    },
+    {
+      provide: AUTH_CFG,
+      useFactory: (cs: ConfigService) => {
+        const cfg = cs.get<IAuthConfig>('auth');
+        if (!cfg) throw new Error('ConfigBridgeModule: auth config not loaded — ensure authConfig is in ConfigModule.forRoot load array');
+        return cfg;
+      },
+      inject: [ConfigService],
+    },
+    {
+      provide: RAG_CFG,
+      useFactory: (cs: ConfigService) => {
+        const cfg = cs.get<IRagConfig>('rag');
+        if (!cfg) throw new Error('ConfigBridgeModule: rag config not loaded — ensure ragConfig is in ConfigModule.forRoot load array');
+        return cfg;
+      },
+      inject: [ConfigService],
+    },
+    {
+      provide: VCS_CFG,
+      useFactory: (cs: ConfigService) => {
+        const cfg = cs.get<IVcsConfig>('vcs');
+        if (!cfg) throw new Error('ConfigBridgeModule: vcs config not loaded — ensure vcsConfig is in ConfigModule.forRoot load array');
+        return cfg;
+      },
+      inject: [ConfigService],
+    },
   ],
   exports: [APP_CFG, AUTH_CFG, RAG_CFG, VCS_CFG],
 })

--- a/apps/api/src/config/database.config.spec.ts
+++ b/apps/api/src/config/database.config.spec.ts
@@ -1,0 +1,18 @@
+import { databaseConfig, IDatabaseConfig } from './database.config';
+
+describe('databaseConfig', () => {
+  beforeEach(() => {
+    process.env['DATABASE_URL'] = 'file:./test.db';
+    delete process.env['DATABASE_PROVIDER'];
+  });
+
+  afterEach(() => {
+    delete process.env['DATABASE_URL'];
+  });
+
+  it('returns typed IDatabaseConfig with defaults', () => {
+    const cfg: IDatabaseConfig = databaseConfig();
+    expect(cfg.url).toBe('file:./test.db');
+    expect(cfg.provider).toBe('sqlite');
+  });
+});

--- a/apps/api/src/config/database.config.ts
+++ b/apps/api/src/config/database.config.ts
@@ -1,6 +1,27 @@
+import { validateUtil } from '@nathapp/nestjs-common';
 import { registerAs } from '@nestjs/config';
+import { IsOptional, IsString } from 'class-validator';
 
-export const databaseConfig = registerAs('database', () => ({
-  url: process.env['DATABASE_URL'],
-  provider: process.env['DATABASE_PROVIDER'] ?? 'sqlite',
-}));
+export const DATABASE_CFG = 'database';
+
+export interface IDatabaseConfig {
+  url: string | undefined;
+  provider: string;
+}
+
+export class DatabaseConfigSchema {
+  @IsString()
+  DATABASE_URL: string;
+
+  @IsOptional()
+  @IsString()
+  DATABASE_PROVIDER: string;
+}
+
+export const databaseConfig = registerAs(DATABASE_CFG, (): IDatabaseConfig => {
+  validateUtil(process.env, DatabaseConfigSchema);
+  return {
+    url: process.env['DATABASE_URL'],
+    provider: process.env['DATABASE_PROVIDER'] ?? 'sqlite',
+  };
+});

--- a/apps/api/src/config/database.config.ts
+++ b/apps/api/src/config/database.config.ts
@@ -5,7 +5,7 @@ import { IsOptional, IsString } from 'class-validator';
 export const DATABASE_CFG = 'database';
 
 export interface IDatabaseConfig {
-  url: string | undefined;
+  url: string;
   provider: string;
 }
 

--- a/apps/api/src/config/rag.config.spec.ts
+++ b/apps/api/src/config/rag.config.spec.ts
@@ -1,0 +1,25 @@
+import { ragConfig, IRagConfig } from './rag.config';
+
+describe('ragConfig', () => {
+  beforeEach(() => {
+    Object.keys(process.env)
+      .filter((k) => ['EMBEDDING_PROVIDER', 'EMBEDDING_MODEL', 'OLLAMA_BASE_URL',
+        'OPENAI_API_KEY', 'LANCEDB_PATH', 'RAG_IN_MEMORY_ONLY', 'FTS_INDEX_MODE',
+        'SIMILARITY_HIGH', 'SIMILARITY_MEDIUM', 'SIMILARITY_LOW',
+        'FTS_OPTIMIZE_STRATEGY', 'FTS_OPTIMIZE_THRESHOLD', 'FTS_OPTIMIZE_INTERVAL_MS',
+        'GRAPHIFY_CACHE_TTL_SEC'].includes(k))
+      .forEach((k) => delete process.env[k]);
+    process.env['NODE_ENV'] = 'test';
+  });
+
+  it('returns typed IRagConfig with defaults', () => {
+    const cfg: IRagConfig = ragConfig();
+    expect(cfg.embeddingProvider).toBe('ollama');
+    expect(cfg.embeddingModel).toBe('nomic-embed-text');
+    expect(cfg.lancedbPath).toBe('./lancedb');
+    expect(cfg.inMemoryOnly).toBe(true); // NODE_ENV=test defaults to true
+    expect(cfg.similarityHigh).toBe(0.85);
+    expect(cfg.ftsOptimizeThreshold).toBe(10);
+    expect(cfg.graphifyEnabledCacheTtlSec).toBe(60);
+  });
+});

--- a/apps/api/src/config/rag.config.ts
+++ b/apps/api/src/config/rag.config.ts
@@ -1,24 +1,102 @@
+import { validateUtil } from '@nathapp/nestjs-common';
 import { registerAs } from '@nestjs/config';
+import { IsBoolean, IsNumber, IsOptional, IsString } from 'class-validator';
 
-export const ragConfig = registerAs('rag', () => ({
-  embeddingProvider: process.env['EMBEDDING_PROVIDER'] ?? 'ollama',
-  embeddingModel: process.env['EMBEDDING_MODEL'] ?? 'nomic-embed-text',
-  ollamaBaseUrl: process.env['OLLAMA_BASE_URL'] ?? 'http://localhost:11434',
-  openaiApiKey: process.env['OPENAI_API_KEY'] ?? '',
-  lancedbPath: process.env['LANCEDB_PATH'] ?? './lancedb',
-  inMemoryOnly: process.env['RAG_IN_MEMORY_ONLY']
-    ? process.env['RAG_IN_MEMORY_ONLY'].toLowerCase() === 'true'
-    : process.env['NODE_ENV'] === 'test',
-  ftsIndexMode: process.env['FTS_INDEX_MODE'] ?? 'simple',
-  // Similarity thresholds for RRF + verdict tiers.
-  // SIMILARITY_HIGH: score >= this → 'high' tier / 'likely_duplicate' verdict.
-  // SIMILARITY_MEDIUM: score >= this → 'medium' tier / 'possibly_related' verdict.
-  // SIMILARITY_LOW: score >= this → 'low' tier; below all three → 'none'.
-  similarityHigh: parseFloat(process.env['SIMILARITY_HIGH'] ?? '0.85'),
-  similarityMedium: parseFloat(process.env['SIMILARITY_MEDIUM'] ?? '0.70'),
-  similarityLow: parseFloat(process.env['SIMILARITY_LOW'] ?? '0.50'),
-  // FTS optimize strategy configuration
-  ftsOptimizeStrategy: process.env['FTS_OPTIMIZE_STRATEGY'] ?? 'counter',
-  ftsOptimizeThreshold: parseInt(process.env['FTS_OPTIMIZE_THRESHOLD'] ?? '10', 10),
-  ftsOptimizeIntervalMs: parseInt(process.env['FTS_OPTIMIZE_INTERVAL_MS'] ?? '300000', 10),
-}));
+export const RAG_CFG = 'rag';
+
+export interface IRagConfig {
+  embeddingProvider: string;
+  embeddingModel: string;
+  ollamaBaseUrl: string;
+  openaiApiKey: string;
+  lancedbPath: string;
+  inMemoryOnly: boolean;
+  ftsIndexMode: string;
+  similarityHigh: number;
+  similarityMedium: number;
+  similarityLow: number;
+  ftsOptimizeStrategy: string;
+  ftsOptimizeThreshold: number;
+  ftsOptimizeIntervalMs: number;
+  graphifyEnabledCacheTtlSec: number;
+}
+
+export class RagConfigSchema {
+  @IsOptional()
+  @IsString()
+  EMBEDDING_PROVIDER: string;
+
+  @IsOptional()
+  @IsString()
+  EMBEDDING_MODEL: string;
+
+  @IsOptional()
+  @IsString()
+  OLLAMA_BASE_URL: string;
+
+  @IsOptional()
+  @IsString()
+  OPENAI_API_KEY: string;
+
+  @IsOptional()
+  @IsString()
+  LANCEDB_PATH: string;
+
+  @IsOptional()
+  @IsBoolean()
+  RAG_IN_MEMORY_ONLY: boolean;
+
+  @IsOptional()
+  @IsString()
+  FTS_INDEX_MODE: string;
+
+  @IsOptional()
+  @IsNumber()
+  SIMILARITY_HIGH: number;
+
+  @IsOptional()
+  @IsNumber()
+  SIMILARITY_MEDIUM: number;
+
+  @IsOptional()
+  @IsNumber()
+  SIMILARITY_LOW: number;
+
+  @IsOptional()
+  @IsString()
+  FTS_OPTIMIZE_STRATEGY: string;
+
+  @IsOptional()
+  @IsNumber()
+  FTS_OPTIMIZE_THRESHOLD: number;
+
+  @IsOptional()
+  @IsNumber()
+  FTS_OPTIMIZE_INTERVAL_MS: number;
+
+  @IsOptional()
+  @IsNumber()
+  GRAPHIFY_CACHE_TTL_SEC: number;
+}
+
+export const ragConfig = registerAs(RAG_CFG, (): IRagConfig => {
+  validateUtil(process.env, RagConfigSchema);
+  return {
+    embeddingProvider: process.env['EMBEDDING_PROVIDER'] ?? 'ollama',
+    embeddingModel: process.env['EMBEDDING_MODEL'] ?? 'nomic-embed-text',
+    ollamaBaseUrl: process.env['OLLAMA_BASE_URL'] ?? 'http://localhost:11434',
+    openaiApiKey: process.env['OPENAI_API_KEY'] ?? '',
+    lancedbPath: process.env['LANCEDB_PATH'] ?? './lancedb',
+    inMemoryOnly: process.env['RAG_IN_MEMORY_ONLY']
+      ? process.env['RAG_IN_MEMORY_ONLY'].toLowerCase() === 'true'
+      : process.env['NODE_ENV'] === 'test',
+    ftsIndexMode: process.env['FTS_INDEX_MODE'] ?? 'simple',
+    similarityHigh: parseFloat(process.env['SIMILARITY_HIGH'] ?? '0.85'),
+    similarityMedium: parseFloat(process.env['SIMILARITY_MEDIUM'] ?? '0.70'),
+    similarityLow: parseFloat(process.env['SIMILARITY_LOW'] ?? '0.50'),
+    ftsOptimizeStrategy: process.env['FTS_OPTIMIZE_STRATEGY'] ?? 'counter',
+    ftsOptimizeThreshold: parseInt(process.env['FTS_OPTIMIZE_THRESHOLD'] ?? '10', 10),
+    ftsOptimizeIntervalMs: parseInt(process.env['FTS_OPTIMIZE_INTERVAL_MS'] ?? '300000', 10),
+    graphifyEnabledCacheTtlSec: parseInt(process.env['GRAPHIFY_CACHE_TTL_SEC'] ?? '60', 10),
+  };
+});

--- a/apps/api/src/config/vcs.config.spec.ts
+++ b/apps/api/src/config/vcs.config.spec.ts
@@ -1,6 +1,6 @@
 /// <reference types="jest" />
 
-import { vcsConfig } from './vcs.config';
+import { IVcsConfig, vcsConfig } from './vcs.config';
 
 describe('vcsConfig', () => {
   describe('namespace registration', () => {
@@ -187,6 +187,14 @@ describe('vcsConfig', () => {
       expect(config2.defaultPollingIntervalMs).toBe(120000);
 
       delete process.env['VCS_DEFAULT_POLLING_INTERVAL_MS'];
+    });
+  });
+
+  describe('TypeScript interface', () => {
+    it('return value satisfies IVcsConfig interface', () => {
+      const cfg: IVcsConfig = vcsConfig();
+      expect(typeof cfg.defaultPollingIntervalMs).toBe('number');
+      expect(typeof cfg.githubApiUrl).toBe('string');
     });
   });
 });

--- a/apps/api/src/config/vcs.config.ts
+++ b/apps/api/src/config/vcs.config.ts
@@ -1,10 +1,37 @@
+import { validateUtil } from '@nathapp/nestjs-common';
 import { registerAs } from '@nestjs/config';
+import { IsNumber, IsOptional, IsString } from 'class-validator';
 
-export const vcsConfig = registerAs('vcs', () => ({
-  encryptionKey: process.env['VCS_ENCRYPTION_KEY'],
-  defaultPollingIntervalMs: parseInt(
-    process.env['VCS_DEFAULT_POLLING_INTERVAL_MS'] ?? '600000',
-    10,
-  ),
-  githubApiUrl: process.env['GITHUB_API_URL'] ?? 'https://api.github.com',
-}));
+export const VCS_CFG = 'vcs';
+
+export interface IVcsConfig {
+  encryptionKey: string | undefined;
+  defaultPollingIntervalMs: number;
+  githubApiUrl: string;
+}
+
+export class VcsConfigSchema {
+  @IsOptional()
+  @IsString()
+  VCS_ENCRYPTION_KEY: string;
+
+  @IsOptional()
+  @IsNumber()
+  VCS_DEFAULT_POLLING_INTERVAL_MS: number;
+
+  @IsOptional()
+  @IsString()
+  GITHUB_API_URL: string;
+}
+
+export const vcsConfig = registerAs(VCS_CFG, (): IVcsConfig => {
+  validateUtil(process.env, VcsConfigSchema);
+  return {
+    encryptionKey: process.env['VCS_ENCRYPTION_KEY'],
+    defaultPollingIntervalMs: parseInt(
+      process.env['VCS_DEFAULT_POLLING_INTERVAL_MS'] ?? '600000',
+      10,
+    ),
+    githubApiUrl: process.env['GITHUB_API_URL'] ?? 'https://api.github.com',
+  };
+});

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -4,6 +4,7 @@ import { Logger } from '@nathapp/nestjs-logging';
 import { HttpAdapterHost } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { CombinedAuthGuard } from './auth/guards/combined-auth.guard';
+import { APP_CFG, IAppConfig } from './config/app.config';
 
 async function bootstrap() {
   const app = await AppFactory.createFastifyApp(AppModule, {
@@ -35,8 +36,7 @@ async function bootstrap() {
     return Readable.from([body]);
   });
 
-  const apiPort = parseInt(process.env.API_PORT || '3100', 10);
-  const apiHost = process.env.API_HOST || '0.0.0.0';
+  const { port, host } = app.get<IAppConfig>(APP_CFG);
 
   // DI container is ready right after createFastifyApp() — get the guard before
   // setting up global handlers. Global guards MUST be registered before init()
@@ -55,7 +55,7 @@ async function bootstrap() {
       version: '1.0.0',
     });
 
-  await app.start(apiPort, apiHost);
+  await app.start(port, host);
 }
 
 bootstrap();

--- a/apps/api/src/rag/embedding.service.spec.ts
+++ b/apps/api/src/rag/embedding.service.spec.ts
@@ -1,17 +1,37 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { ConfigService } from '@nestjs/config';
 import { ValidationAppException } from '@nathapp/nestjs-common';
+import { RAG_CFG, IRagConfig } from '../config/rag.config';
 import { EmbeddingService } from './embedding.service';
 import { OllamaEmbeddingProvider } from './providers/ollama-embedding.provider';
 import { OpenAIEmbeddingProvider } from './providers/openai-embedding.provider';
 
-function buildModule(config: Record<string, unknown>): Promise<TestingModule> {
+function makeRagConfig(overrides: Partial<IRagConfig> = {}): IRagConfig {
+  return {
+    embeddingProvider: 'ollama',
+    embeddingModel: 'nomic-embed-text',
+    ollamaBaseUrl: 'http://localhost:11434',
+    openaiApiKey: '',
+    lancedbPath: './lancedb',
+    inMemoryOnly: true,
+    ftsIndexMode: 'simple',
+    similarityHigh: 0.85,
+    similarityMedium: 0.70,
+    similarityLow: 0.50,
+    ftsOptimizeStrategy: 'counter',
+    ftsOptimizeThreshold: 10,
+    ftsOptimizeIntervalMs: 300000,
+    graphifyEnabledCacheTtlSec: 60,
+    ...overrides,
+  };
+}
+
+function buildModule(ragConfig: IRagConfig): Promise<TestingModule> {
   return Test.createTestingModule({
     providers: [
       EmbeddingService,
       {
-        provide: ConfigService,
-        useValue: { get: (key: string) => config[key] },
+        provide: RAG_CFG,
+        useValue: ragConfig,
       },
     ],
   }).compile();
@@ -20,39 +40,39 @@ function buildModule(config: Record<string, unknown>): Promise<TestingModule> {
 describe('EmbeddingService', () => {
   describe('provider factory', () => {
     it('creates OllamaEmbeddingProvider when provider is "ollama"', async () => {
-      const module = await buildModule({
-        'rag.embeddingProvider': 'ollama',
-        'rag.embeddingModel': 'nomic-embed-text',
-        'rag.ollamaBaseUrl': 'http://localhost:11434',
-      });
+      const module = await buildModule(makeRagConfig({
+        embeddingProvider: 'ollama',
+        embeddingModel: 'nomic-embed-text',
+        ollamaBaseUrl: 'http://localhost:11434',
+      }));
       const service = module.get(EmbeddingService);
       expect(service.providerName).toBe('ollama');
       expect(service.dimensions).toBe(768);
     });
 
     it('creates OpenAIEmbeddingProvider when provider is "openai"', async () => {
-      const module = await buildModule({
-        'rag.embeddingProvider': 'openai',
-        'rag.embeddingModel': 'text-embedding-3-small',
-        'rag.openaiApiKey': 'sk-test-key',
-      });
+      const module = await buildModule(makeRagConfig({
+        embeddingProvider: 'openai',
+        embeddingModel: 'text-embedding-3-small',
+        openaiApiKey: 'sk-test-key',
+      }));
       const service = module.get(EmbeddingService);
       expect(service.providerName).toBe('openai');
       expect(service.dimensions).toBe(1536);
     });
 
     it('defaults to ollama when no provider configured', async () => {
-      const module = await buildModule({});
+      const module = await buildModule(makeRagConfig());
       const service = module.get(EmbeddingService);
       expect(service.providerName).toBe('ollama');
     });
 
     it('exposes correct model name', async () => {
-      const module = await buildModule({
-        'rag.embeddingProvider': 'ollama',
-        'rag.embeddingModel': 'mxbai-embed-large',
-        'rag.ollamaBaseUrl': 'http://localhost:11434',
-      });
+      const module = await buildModule(makeRagConfig({
+        embeddingProvider: 'ollama',
+        embeddingModel: 'mxbai-embed-large',
+        ollamaBaseUrl: 'http://localhost:11434',
+      }));
       const service = module.get(EmbeddingService);
       expect(service.modelName).toBe('mxbai-embed-large');
     });

--- a/apps/api/src/rag/embedding.service.ts
+++ b/apps/api/src/rag/embedding.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Inject } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
+import { RAG_CFG, IRagConfig } from '../config/rag.config';
 import { EmbeddingProvider } from './embedding.interface';
 import { OllamaEmbeddingProvider } from './providers/ollama-embedding.provider';
 import { OpenAIEmbeddingProvider } from './providers/openai-embedding.provider';
@@ -9,17 +9,14 @@ export class EmbeddingService {
   private readonly provider: EmbeddingProvider;
   private readonly _modelName: string;
 
-  constructor(@Inject(ConfigService) configService: ConfigService) {
-    const providerName = configService.get<string>('rag.embeddingProvider') ?? 'ollama';
-    const model = configService.get<string>('rag.embeddingModel') ?? 'nomic-embed-text';
-    this._modelName = model;
+  constructor(@Inject(RAG_CFG) ragConfig: IRagConfig) {
+    const { embeddingProvider, embeddingModel, openaiApiKey, ollamaBaseUrl } = ragConfig;
+    this._modelName = embeddingModel;
 
-    if (providerName === 'openai') {
-      const apiKey = configService.get<string>('rag.openaiApiKey') ?? '';
-      this.provider = new OpenAIEmbeddingProvider(apiKey, model);
+    if (embeddingProvider === 'openai') {
+      this.provider = new OpenAIEmbeddingProvider(openaiApiKey, embeddingModel);
     } else {
-      const baseUrl = configService.get<string>('rag.ollamaBaseUrl') ?? 'http://localhost:11434';
-      this.provider = new OllamaEmbeddingProvider(baseUrl, model);
+      this.provider = new OllamaEmbeddingProvider(ollamaBaseUrl, embeddingModel);
     }
   }
 

--- a/apps/api/src/rag/hybrid-retriever.service.spec.ts
+++ b/apps/api/src/rag/hybrid-retriever.service.spec.ts
@@ -24,22 +24,29 @@ jest.mock('@lancedb/lancedb', () => ({
 }));
 
 import { HybridRetrieverService } from './hybrid-retriever.service';
-import type { ConfigService } from '@nestjs/config';
+import type { IRagConfig } from '../config/rag.config';
 import type { EmbeddingService } from './embedding.service';
 import type { EntityStore } from './entity-store';
 import type { PrismaRagRepository } from './prisma-rag.repository';
 
-function makeConfigService(overrides: Record<string, unknown> = {}): jest.Mocked<ConfigService> {
-  const defaults: Record<string, unknown> = {
-    'rag.lancedbPath': './lancedb-test',
-    'rag.similarityHigh': 0.85,
-    'rag.similarityMedium': 0.7,
-    'rag.similarityLow': 0.5,
-    'rag.inMemoryOnly': true,
-    'rag.graphifyEnabledCacheTtlSec': 60,
+function makeRagConfig(overrides: Partial<IRagConfig> = {}): IRagConfig {
+  return {
+    embeddingProvider: 'ollama',
+    embeddingModel: 'nomic-embed-text',
+    ollamaBaseUrl: 'http://localhost:11434',
+    openaiApiKey: '',
+    lancedbPath: './lancedb-test',
+    inMemoryOnly: true,
+    ftsIndexMode: 'simple',
+    similarityHigh: 0.85,
+    similarityMedium: 0.7,
+    similarityLow: 0.5,
+    ftsOptimizeStrategy: 'counter',
+    ftsOptimizeThreshold: 10,
+    ftsOptimizeIntervalMs: 300000,
+    graphifyEnabledCacheTtlSec: 60,
     ...overrides,
   };
-  return { get: jest.fn((key: string) => defaults[key]) } as unknown as jest.Mocked<ConfigService>;
 }
 
 function makeEmbeddingService(): jest.Mocked<EmbeddingService> {
@@ -64,19 +71,19 @@ function makeRagRepo(): jest.Mocked<PrismaRagRepository> {
   } as unknown as jest.Mocked<PrismaRagRepository>;
 }
 
-function buildService(configOverrides: Record<string, unknown> = {}): {
+function buildService(configOverrides: Partial<IRagConfig> = {}): {
   service: HybridRetrieverService;
-  config: jest.Mocked<ConfigService>;
+  ragConfig: IRagConfig;
   embeddingService: jest.Mocked<EmbeddingService>;
   entityStore: jest.Mocked<EntityStore>;
   ragRepo: jest.Mocked<PrismaRagRepository>;
 } {
-  const config = makeConfigService(configOverrides);
+  const ragConfig = makeRagConfig(configOverrides);
   const embeddingService = makeEmbeddingService();
   const entityStore = makeEntityStore();
   const ragRepo = makeRagRepo();
-  const service = new HybridRetrieverService(config, embeddingService, entityStore, ragRepo);
-  return { service, config, embeddingService, entityStore, ragRepo };
+  const service = new HybridRetrieverService(ragConfig, embeddingService, entityStore, ragRepo);
+  return { service, ragConfig, embeddingService, entityStore, ragRepo };
 }
 
 describe('HybridRetrieverService', () => {
@@ -86,13 +93,13 @@ describe('HybridRetrieverService', () => {
 
   describe('constructor / onModuleInit', () => {
     it('sets inMemoryOnly mode from config', () => {
-      const { service } = buildService({ 'rag.inMemoryOnly': true });
+      const { service } = buildService({ inMemoryOnly: true });
       // lanceAvailable is false in in-memory mode — verify by calling onModuleInit without throwing
       expect(() => service.onModuleInit()).not.toThrow();
     });
 
     it('does not throw on onModuleInit when inMemoryOnly=true', () => {
-      const { service } = buildService({ 'rag.inMemoryOnly': true });
+      const { service } = buildService({ inMemoryOnly: true });
       expect(() => service.onModuleInit()).not.toThrow();
     });
   });
@@ -113,7 +120,7 @@ describe('HybridRetrieverService', () => {
 
   describe('indexDocument', () => {
     it('embeds content and adds record to the in-memory table', async () => {
-      const { service, embeddingService } = buildService({ 'rag.inMemoryOnly': true });
+      const { service, embeddingService } = buildService({ inMemoryOnly: true });
       embeddingService.embed.mockResolvedValue(Array(8).fill(0.5));
 
       await expect(
@@ -129,7 +136,7 @@ describe('HybridRetrieverService', () => {
     });
 
     it('falls back to zero vector when embed throws', async () => {
-      const { service, embeddingService } = buildService({ 'rag.inMemoryOnly': true });
+      const { service, embeddingService } = buildService({ inMemoryOnly: true });
       embeddingService.embed.mockRejectedValueOnce(new Error('embed error'));
 
       await expect(
@@ -143,7 +150,7 @@ describe('HybridRetrieverService', () => {
     });
 
     it('uses createdAtOverride from metadata when present', async () => {
-      const { service, embeddingService } = buildService({ 'rag.inMemoryOnly': true });
+      const { service, embeddingService } = buildService({ inMemoryOnly: true });
       embeddingService.embed.mockResolvedValue(Array(8).fill(0));
 
       await expect(
@@ -159,7 +166,7 @@ describe('HybridRetrieverService', () => {
 
   describe('search', () => {
     it('returns empty results when table has no rows', async () => {
-      const { service } = buildService({ 'rag.inMemoryOnly': true });
+      const { service } = buildService({ inMemoryOnly: true });
 
       const result = await service.search({
         projectId: 'proj-1',
@@ -172,7 +179,7 @@ describe('HybridRetrieverService', () => {
     });
 
     it('respects explicit graphifyEnabled=false to exclude code sources', async () => {
-      const { service } = buildService({ 'rag.inMemoryOnly': true });
+      const { service } = buildService({ inMemoryOnly: true });
 
       const result = await service.search({
         projectId: 'proj-1',
@@ -184,7 +191,7 @@ describe('HybridRetrieverService', () => {
     });
 
     it('caps limit at 50', async () => {
-      const { service } = buildService({ 'rag.inMemoryOnly': true });
+      const { service } = buildService({ inMemoryOnly: true });
 
       const result = await service.search({
         projectId: 'proj-1',
@@ -197,7 +204,7 @@ describe('HybridRetrieverService', () => {
     });
 
     it('uses intent-specific weights when intent is provided', async () => {
-      const { service } = buildService({ 'rag.inMemoryOnly': true });
+      const { service } = buildService({ inMemoryOnly: true });
 
       const result = await service.search({
         projectId: 'proj-1',
@@ -209,7 +216,7 @@ describe('HybridRetrieverService', () => {
     });
 
     it('resolves graphifyEnabled from repo when not supplied explicitly', async () => {
-      const { service, ragRepo } = buildService({ 'rag.inMemoryOnly': true });
+      const { service, ragRepo } = buildService({ inMemoryOnly: true });
       ragRepo.findProjectGraphifyEnabled.mockResolvedValue({ graphifyEnabled: true } as any);
 
       await service.search({ projectId: 'proj-cache', query: 'test' });
@@ -220,7 +227,7 @@ describe('HybridRetrieverService', () => {
     });
 
     it('invalidateGraphifyEnabledCache forces repo re-fetch', async () => {
-      const { service, ragRepo } = buildService({ 'rag.inMemoryOnly': true });
+      const { service, ragRepo } = buildService({ inMemoryOnly: true });
       ragRepo.findProjectGraphifyEnabled.mockResolvedValue({ graphifyEnabled: false } as any);
 
       await service.search({ projectId: 'proj-2', query: 'a' });

--- a/apps/api/src/rag/hybrid-retriever.service.ts
+++ b/apps/api/src/rag/hybrid-retriever.service.ts
@@ -1,6 +1,6 @@
-import { Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { Injectable, Logger, OnModuleDestroy, OnModuleInit, Inject } from '@nestjs/common';
 import { mkdirSync } from 'node:fs';
-import { ConfigService } from '@nestjs/config';
+import { RAG_CFG, IRagConfig } from '../config/rag.config';
 import { PrismaRagRepository } from './prisma-rag.repository';
 import { EmbeddingService } from './embedding.service';
 import { EntityStore } from './entity-store';
@@ -82,18 +82,17 @@ export class HybridRetrieverService implements OnModuleInit, OnModuleDestroy {
   private readonly graphifyEnabledCacheTtlMs: number;
 
   constructor(
-    private readonly configService: ConfigService,
+    @Inject(RAG_CFG) ragConfig: IRagConfig,
     private readonly embeddingService: EmbeddingService,
     private readonly entityStore: EntityStore,
     private readonly ragRepository: PrismaRagRepository,
   ) {
-    this.lancedbPath = configService.get<string>('rag.lancedbPath') ?? './lancedb';
-    this.similarityHigh = configService.get<number>('rag.similarityHigh') ?? 0.85;
-    this.similarityMedium = configService.get<number>('rag.similarityMedium') ?? 0.7;
-    this.similarityLow = configService.get<number>('rag.similarityLow') ?? 0.5;
-    this.inMemoryOnly = configService.get<boolean>('rag.inMemoryOnly') ?? false;
-    this.graphifyEnabledCacheTtlMs = configService.get<number>('rag.graphifyEnabledCacheTtlSec') ?? 60;
-    this.graphifyEnabledCacheTtlMs = this.graphifyEnabledCacheTtlMs * 1000;
+    this.lancedbPath = ragConfig.lancedbPath;
+    this.similarityHigh = ragConfig.similarityHigh;
+    this.similarityMedium = ragConfig.similarityMedium;
+    this.similarityLow = ragConfig.similarityLow;
+    this.inMemoryOnly = ragConfig.inMemoryOnly;
+    this.graphifyEnabledCacheTtlMs = ragConfig.graphifyEnabledCacheTtlSec * 1000;
 
     if (this.inMemoryOnly) {
       this.lanceAvailable = false;

--- a/apps/api/src/rag/rag-config-and-module.spec.ts
+++ b/apps/api/src/rag/rag-config-and-module.spec.ts
@@ -1,10 +1,29 @@
-import { ConfigService } from '@nestjs/config';
 import { SchedulerRegistry } from '@nestjs/schedule';
-import { ragConfig } from '../config/rag.config';
+import { IRagConfig, ragConfig } from '../config/rag.config';
 import { FtsOptimizeStrategy } from './strategies/fts-optimize-strategy.interface';
 import { CounterOptimizeStrategy } from './strategies/counter-optimize.strategy';
 import { CronOptimizeStrategy } from './strategies/cron-optimize.strategy';
 import { ManualOptimizeStrategy } from './strategies/manual-optimize.strategy';
+
+function mockRagConfig(overrides: Partial<IRagConfig> = {}): IRagConfig {
+  return {
+    embeddingProvider: 'ollama',
+    embeddingModel: 'nomic-embed-text',
+    ollamaBaseUrl: 'http://localhost:11434',
+    openaiApiKey: '',
+    lancedbPath: './lancedb',
+    inMemoryOnly: true,
+    ftsIndexMode: 'simple',
+    similarityHigh: 0.85,
+    similarityMedium: 0.70,
+    similarityLow: 0.50,
+    ftsOptimizeStrategy: 'counter',
+    ftsOptimizeThreshold: 10,
+    ftsOptimizeIntervalMs: 300_000,
+    graphifyEnabledCacheTtlSec: 60,
+    ...overrides,
+  };
+}
 
 describe('RAG Config & Module Wiring (US-002)', () => {
   describe('rag.config.ts', () => {
@@ -70,37 +89,29 @@ describe('RAG Config & Module Wiring (US-002)', () => {
     });
 
     describe('FTS_OPTIMIZE_STRATEGY factory', () => {
-      let mockConfigService: ConfigService;
+      let ragCfg: IRagConfig;
       let mockSchedulerRegistry: SchedulerRegistry;
 
       beforeEach(() => {
-        // Mock ConfigService
-        mockConfigService = {
-          get: jest.fn(),
-        } as unknown as ConfigService;
+        ragCfg = mockRagConfig();
 
-        // Mock SchedulerRegistry
         mockSchedulerRegistry = {
           addInterval: jest.fn(),
         } as unknown as SchedulerRegistry;
       });
 
       it('resolves to CounterOptimizeStrategy when ftsOptimizeStrategy is "counter"', () => {
-        jest.spyOn(mockConfigService, 'get').mockReturnValue('counter');
-
-        // Simulate the factory function logic
-        const strategy = mockConfigService.get('rag.ftsOptimizeStrategy') === 'counter'
-          ? new CounterOptimizeStrategy(mockConfigService)
+        const cfg = mockRagConfig({ ftsOptimizeStrategy: 'counter' });
+        const strategy = cfg.ftsOptimizeStrategy === 'counter'
+          ? new CounterOptimizeStrategy(cfg)
           : null;
 
         expect(strategy).toBeInstanceOf(CounterOptimizeStrategy);
       });
 
       it('resolves to ManualOptimizeStrategy when ftsOptimizeStrategy is "manual"', () => {
-        jest.spyOn(mockConfigService, 'get').mockReturnValue('manual');
-
-        // Simulate the factory function logic
-        const strategy = mockConfigService.get('rag.ftsOptimizeStrategy') === 'manual'
+        const cfg = mockRagConfig({ ftsOptimizeStrategy: 'manual' });
+        const strategy = cfg.ftsOptimizeStrategy === 'manual'
           ? new ManualOptimizeStrategy()
           : null;
 
@@ -108,35 +119,33 @@ describe('RAG Config & Module Wiring (US-002)', () => {
       });
 
       it('resolves to CronOptimizeStrategy when ftsOptimizeStrategy is "cron"', () => {
-        jest.spyOn(mockConfigService, 'get').mockReturnValue('cron');
-
-        // Simulate the factory function logic
-        const strategy = mockConfigService.get('rag.ftsOptimizeStrategy') === 'cron'
-          ? new CronOptimizeStrategy(mockConfigService, mockSchedulerRegistry)
+        const cfg = mockRagConfig({ ftsOptimizeStrategy: 'cron' });
+        const strategy = cfg.ftsOptimizeStrategy === 'cron'
+          ? new CronOptimizeStrategy(cfg, mockSchedulerRegistry)
           : null;
 
         expect(strategy).toBeInstanceOf(CronOptimizeStrategy);
       });
 
       it('resolves to CounterOptimizeStrategy when ftsOptimizeStrategy is unknown value', () => {
-        jest.spyOn(mockConfigService, 'get').mockReturnValue('unknown-strategy');
-
-        // Simulate the factory function logic (defaults to counter)
-        const configValue = mockConfigService.get('rag.ftsOptimizeStrategy');
+        const cfg = mockRagConfig({ ftsOptimizeStrategy: 'unknown-strategy' });
         let strategy: FtsOptimizeStrategy;
-        switch (configValue) {
+        switch (cfg.ftsOptimizeStrategy) {
           case 'cron':
-            strategy = new CronOptimizeStrategy(mockConfigService, mockSchedulerRegistry);
+            strategy = new CronOptimizeStrategy(cfg, mockSchedulerRegistry);
             break;
           case 'manual':
             strategy = new ManualOptimizeStrategy();
             break;
           default:
-            strategy = new CounterOptimizeStrategy(mockConfigService);
+            strategy = new CounterOptimizeStrategy(cfg);
         }
 
         expect(strategy).toBeInstanceOf(CounterOptimizeStrategy);
       });
+
+      // Suppress unused variable warning — ragCfg is used in beforeEach to test default state
+      void ragCfg;
     });
   });
 });

--- a/apps/api/src/rag/rag.module.ts
+++ b/apps/api/src/rag/rag.module.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger, Module, OnModuleInit, Optional, forwardRef } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
 import { ScheduleModule, SchedulerRegistry } from '@nestjs/schedule';
+import { RAG_CFG, IRagConfig } from '../config/rag.config';
 import { PrismaModule } from '@nathapp/nestjs-prisma';
 import { RagController } from './rag.controller';
 import { RagService } from './rag.service';
@@ -138,20 +138,20 @@ class EntityStoreWarmup implements OnModuleInit {
     IncrementalGraphDiffService,
     {
       provide: FTS_OPTIMIZE_STRATEGY,
-      useFactory: (configService: ConfigService, schedulerRegistry: SchedulerRegistry): FtsOptimizeStrategy => {
-        const strategy = configService.get<string>('rag.ftsOptimizeStrategy') ?? 'counter';
+      useFactory: (ragConfig: IRagConfig, schedulerRegistry: SchedulerRegistry): FtsOptimizeStrategy => {
+        const strategy = ragConfig.ftsOptimizeStrategy;
 
         switch (strategy) {
           case 'cron':
-            return new CronOptimizeStrategy(configService, schedulerRegistry);
+            return new CronOptimizeStrategy(ragConfig, schedulerRegistry);
           case 'manual':
             return new ManualOptimizeStrategy();
           case 'counter':
           default:
-            return new CounterOptimizeStrategy(configService);
+            return new CounterOptimizeStrategy(ragConfig);
         }
       },
-      inject: [ConfigService, SchedulerRegistry],
+      inject: [RAG_CFG, SchedulerRegistry],
     },
   ],
   exports: [RagService, HybridRetrieverService, LexicalIndex, EntityStore, GraphStoreService, FTS_OPTIMIZE_STRATEGY, IncrementalGraphDiffService],

--- a/apps/api/src/rag/rag.service.spec.ts
+++ b/apps/api/src/rag/rag.service.spec.ts
@@ -23,6 +23,7 @@ jest.mock('@lancedb/lancedb', () => ({
   Index: { fts: jest.fn().mockReturnValue({}) },
 }));
 
+import { IRagConfig } from '../config/rag.config';
 import {
   RagService,
   reciprocalRankFusion,
@@ -33,6 +34,26 @@ import {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyRecord = Record<string, any>;
+
+function makeRagConfig(overrides: Partial<IRagConfig> = {}): IRagConfig {
+  return {
+    embeddingProvider: 'ollama',
+    embeddingModel: 'nomic-embed-text',
+    ollamaBaseUrl: 'http://localhost:11434',
+    openaiApiKey: '',
+    lancedbPath: './lancedb',
+    inMemoryOnly: false,
+    ftsIndexMode: 'simple',
+    similarityHigh: 0.85,
+    similarityMedium: 0.70,
+    similarityLow: 0.50,
+    ftsOptimizeStrategy: 'counter',
+    ftsOptimizeThreshold: 10,
+    ftsOptimizeIntervalMs: 300000,
+    graphifyEnabledCacheTtlSec: 60,
+    ...overrides,
+  };
+}
 
 function makeMockRecord(id: string, content: string): AnyRecord {
   return {
@@ -48,18 +69,7 @@ function makeMockRecord(id: string, content: string): AnyRecord {
   };
 }
 
-const mockConfigServiceForSearch = {
-  get: (key: string): unknown => {
-    const config: Record<string, unknown> = {
-      'rag.lancedbPath': './lancedb',
-      'rag.similarityHigh': 0.85,
-      'rag.similarityMedium': 0.70,
-      'rag.similarityLow': 0.50,
-      'rag.ftsIndexMode': 'simple',
-    };
-    return config[key];
-  },
-};
+const mockRagConfigForSearch = makeRagConfig();
 
 const mockEmbeddingServiceForSearch = {
   embed: jest.fn().mockResolvedValue(new Float32Array(384).fill(0)),
@@ -198,20 +208,7 @@ describe('getVerdict', () => {
 
 describe('RagService lifecycle', () => {
   it('closes LanceDB connection on module destroy', () => {
-    const configService = {
-      get: (key: string): unknown => {
-        const config: Record<string, unknown> = {
-          'rag.lancedbPath': './lancedb',
-          'rag.similarityHigh': 0.85,
-          'rag.similarityMedium': 0.70,
-          'rag.similarityLow': 0.50,
-          'rag.ftsIndexMode': 'simple',
-        };
-        return config[key];
-      },
-    };
-
-    const ragService = new RagService(configService as never);
+    const ragService = new RagService(makeRagConfig());
     const closeSpy = jest.fn();
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -226,21 +223,10 @@ describe('RagService lifecycle', () => {
 });
 
 describe('RagService.getOrCreateTable — FTS index creation', () => {
-  const mockConfigService = {
-    get: (key: string): unknown => {
-      const config: Record<string, unknown> = {
-        'rag.lancedbPath': './lancedb',
-        'rag.similarityHigh': 0.85,
-        'rag.similarityMedium': 0.70,
-        'rag.similarityLow': 0.50,
-        'rag.ftsIndexMode': 'simple',
-      };
-      return config[key];
-    },
-  };
+  const mockRagConfig = makeRagConfig();
 
   it('calls table.createIndex with FTS config when lanceAvailable is true', async () => {
-    const ragService = new RagService(mockConfigService as never);
+    const ragService = new RagService(mockRagConfig);
     const createIndexSpy = jest.fn().mockResolvedValue(undefined);
     const deleteSpy = jest.fn().mockResolvedValue(undefined);
 
@@ -269,7 +255,7 @@ describe('RagService.getOrCreateTable — FTS index creation', () => {
   });
 
   it('does not call table.createIndex when lanceAvailable is false', async () => {
-    const ragService = new RagService(mockConfigService as never);
+    const ragService = new RagService(mockRagConfig);
     ragService.onModuleInit();
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -283,7 +269,7 @@ describe('RagService.getOrCreateTable — FTS index creation', () => {
   });
 
   it('logs warning and does not throw when createIndex rejects', async () => {
-    const ragService = new RagService(mockConfigService as never);
+    const ragService = new RagService(mockRagConfig);
     const loggerSpy = jest.spyOn(ragService['logger'], 'warn');
     const createIndexError = new Error('Index already exists');
     const createIndexSpy = jest.fn().mockRejectedValue(createIndexError);
@@ -339,7 +325,7 @@ describe('RagService.search — native FTS path (US-003-2)', () => {
 
   it('calls table.search(query, "fts", "content") when lanceAvailable is true', async () => {
     const ragService = new RagService(
-      mockConfigServiceForSearch as never,
+      mockRagConfigForSearch,
       mockEmbeddingServiceForSearch as never,
     );
 
@@ -358,7 +344,7 @@ describe('RagService.search — native FTS path (US-003-2)', () => {
 
   it('does not call table.search() when lanceAvailable is false', async () => {
     const ragService = new RagService(
-      mockConfigServiceForSearch as never,
+      mockRagConfigForSearch,
       mockEmbeddingServiceForSearch as never,
     );
 
@@ -377,7 +363,7 @@ describe('RagService.search — native FTS path (US-003-2)', () => {
 
   it('scores native FTS results by reciprocal position 1/(i+1)', async () => {
     const ragService = new RagService(
-      mockConfigServiceForSearch as never,
+      mockRagConfigForSearch,
       mockEmbeddingServiceForSearch as never,
     );
 
@@ -408,7 +394,7 @@ describe('RagService.search — native FTS path (US-003-2)', () => {
 
   it('adds ftsRows to recordMap so records unique to native FTS appear in results', async () => {
     const ragService = new RagService(
-      mockConfigServiceForSearch as never,
+      mockRagConfigForSearch,
       mockEmbeddingServiceForSearch as never,
     );
 
@@ -454,7 +440,7 @@ describe('RagService.search — in-memory FTS fallback path (US-003-3)', () => {
 
   it('when lanceAvailable=true and table.search() rejects, falls back to simpleFtsScore and returns non-empty results', async () => {
     const ragService = new RagService(
-      mockConfigServiceForSearch as never,
+      mockRagConfigForSearch,
       mockEmbeddingServiceForSearch as never,
     );
 
@@ -477,7 +463,7 @@ describe('RagService.search — in-memory FTS fallback path (US-003-3)', () => {
 
   it('when lanceAvailable=true and table.search() rejects, logs a warning', async () => {
     const ragService = new RagService(
-      mockConfigServiceForSearch as never,
+      mockRagConfigForSearch,
       mockEmbeddingServiceForSearch as never,
     );
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -499,7 +485,7 @@ describe('RagService.search — in-memory FTS fallback path (US-003-3)', () => {
 
   it('when lanceAvailable=true and table.search() rejects, fallback scores match simpleFtsScore output', async () => {
     const ragService = new RagService(
-      mockConfigServiceForSearch as never,
+      mockRagConfigForSearch,
       mockEmbeddingServiceForSearch as never,
     );
 
@@ -529,7 +515,7 @@ describe('RagService.search — in-memory FTS fallback path (US-003-3)', () => {
 
   it('when lanceAvailable=false, uses simpleFtsScore without calling table.search()', async () => {
     const ragService = new RagService(
-      mockConfigServiceForSearch as never,
+      mockRagConfigForSearch,
       mockEmbeddingServiceForSearch as never,
     );
 
@@ -573,18 +559,7 @@ describe('simpleFtsScore — export (US-003-3 AC-3)', () => {
 });
 
 describe('RagService — onFirstAccess and onDestroy lifecycle hooks (US-003-5)', () => {
-  const mockConfigService = {
-    get: (key: string): unknown => {
-      const config: Record<string, unknown> = {
-        'rag.lancedbPath': './lancedb',
-        'rag.similarityHigh': 0.85,
-        'rag.similarityMedium': 0.70,
-        'rag.similarityLow': 0.50,
-        'rag.ftsIndexMode': 'simple',
-      };
-      return config[key];
-    },
-  };
+  const mockRagConfig = makeRagConfig();
 
   function makeMockDb(tableExists: boolean) {
     const mockTable = {
@@ -601,7 +576,7 @@ describe('RagService — onFirstAccess and onDestroy lifecycle hooks (US-003-5)'
 
   describe('getOrCreateTable — onFirstAccess', () => {
     it('calls optimizeStrategy.onFirstAccess(projectId, table) when lanceAvailable is true', async () => {
-      const ragService = new RagService(mockConfigService as never);
+      const ragService = new RagService(mockRagConfig);
       const onFirstAccessSpy = jest.fn();
       const mockStrategy = { onFirstAccess: onFirstAccessSpy, onInsert: jest.fn(), onDestroy: jest.fn() };
       const { mockTable, ...mockDb } = makeMockDb(false);
@@ -619,7 +594,7 @@ describe('RagService — onFirstAccess and onDestroy lifecycle hooks (US-003-5)'
     });
 
     it('calls optimizeStrategy.onFirstAccess exactly once per projectId even when called multiple times', async () => {
-      const ragService = new RagService(mockConfigService as never);
+      const ragService = new RagService(mockRagConfig);
       const onFirstAccessSpy = jest.fn();
       const mockStrategy = { onFirstAccess: onFirstAccessSpy, onInsert: jest.fn(), onDestroy: jest.fn() };
       const { mockTable, ...mockDb } = makeMockDb(false);
@@ -639,7 +614,7 @@ describe('RagService — onFirstAccess and onDestroy lifecycle hooks (US-003-5)'
     });
 
     it('calls optimizeStrategy.onFirstAccess once per distinct projectId', async () => {
-      const ragService = new RagService(mockConfigService as never);
+      const ragService = new RagService(mockRagConfig);
       const onFirstAccessSpy = jest.fn();
       const mockStrategy = { onFirstAccess: onFirstAccessSpy, onInsert: jest.fn(), onDestroy: jest.fn() };
 
@@ -670,7 +645,7 @@ describe('RagService — onFirstAccess and onDestroy lifecycle hooks (US-003-5)'
     });
 
     it('does not call optimizeStrategy.onFirstAccess when lanceAvailable is false', async () => {
-      const ragService = new RagService(mockConfigService as never);
+      const ragService = new RagService(mockRagConfig);
       const onFirstAccessSpy = jest.fn();
       const mockStrategy = { onFirstAccess: onFirstAccessSpy, onInsert: jest.fn(), onDestroy: jest.fn() };
 
@@ -685,7 +660,7 @@ describe('RagService — onFirstAccess and onDestroy lifecycle hooks (US-003-5)'
     });
 
     it('does not call optimizeStrategy.onFirstAccess when optimizeStrategy is not injected', async () => {
-      const ragService = new RagService(mockConfigService as never);
+      const ragService = new RagService(mockRagConfig);
       const { mockTable, ...mockDb } = makeMockDb(false);
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -700,7 +675,7 @@ describe('RagService — onFirstAccess and onDestroy lifecycle hooks (US-003-5)'
 
   describe('onModuleDestroy — onDestroy', () => {
     it('calls optimizeStrategy.onDestroy() during onModuleDestroy', async () => {
-      const ragService = new RagService(mockConfigService as never);
+      const ragService = new RagService(mockRagConfig);
       const onDestroySpy = jest.fn().mockResolvedValue(undefined);
       const mockStrategy = { onFirstAccess: jest.fn(), onInsert: jest.fn(), onDestroy: onDestroySpy };
 
@@ -713,7 +688,7 @@ describe('RagService — onFirstAccess and onDestroy lifecycle hooks (US-003-5)'
     });
 
     it('calls optimizeStrategy.onDestroy() even when no LanceDB connection exists', async () => {
-      const ragService = new RagService(mockConfigService as never);
+      const ragService = new RagService(mockRagConfig);
       const onDestroySpy = jest.fn().mockResolvedValue(undefined);
       const mockStrategy = { onFirstAccess: jest.fn(), onInsert: jest.fn(), onDestroy: onDestroySpy };
 
@@ -728,7 +703,7 @@ describe('RagService — onFirstAccess and onDestroy lifecycle hooks (US-003-5)'
     });
 
     it('does not throw when optimizeStrategy is not injected', async () => {
-      const ragService = new RagService(mockConfigService as never);
+      const ragService = new RagService(mockRagConfig);
       // optimizeStrategy is undefined (not injected)
 
       await expect(ragService.onModuleDestroy()).resolves.toBeUndefined();
@@ -737,18 +712,7 @@ describe('RagService — onFirstAccess and onDestroy lifecycle hooks (US-003-5)'
 });
 
 describe('RagService.indexDocument — onInsert Strategy Hook (US-003-4)', () => {
-  const mockConfigService = {
-    get: (key: string): unknown => {
-      const config: Record<string, unknown> = {
-        'rag.lancedbPath': './lancedb',
-        'rag.similarityHigh': 0.85,
-        'rag.similarityMedium': 0.70,
-        'rag.similarityLow': 0.50,
-        'rag.ftsIndexMode': 'simple',
-      };
-      return config[key];
-    },
-  };
+  const mockRagConfig = makeRagConfig();
 
   const mockEmbeddingService = {
     embed: jest.fn().mockResolvedValue([0.1, 0.2, 0.3]),
@@ -758,7 +722,7 @@ describe('RagService.indexDocument — onInsert Strategy Hook (US-003-4)', () =>
   };
 
   it('calls optimizeStrategy.onInsert(projectId, table) after table.add() when lanceAvailable is true', async () => {
-    const ragService = new RagService(mockConfigService as never, mockEmbeddingService as never);
+    const ragService = new RagService(mockRagConfig, mockEmbeddingService as never);
     const onInsertSpy = jest.fn().mockResolvedValue(undefined);
     const mockStrategy = { onInsert: onInsertSpy } as unknown as never;
     const mockTable = { add: jest.fn().mockResolvedValue(undefined) };
@@ -781,7 +745,7 @@ describe('RagService.indexDocument — onInsert Strategy Hook (US-003-4)', () =>
   });
 
   it('does not call optimizeStrategy.onInsert() when lanceAvailable is false', async () => {
-    const ragService = new RagService(mockConfigService as never, mockEmbeddingService as never);
+    const ragService = new RagService(mockRagConfig, mockEmbeddingService as never);
     const onInsertSpy = jest.fn().mockResolvedValue(undefined);
     const mockStrategy = { onInsert: onInsertSpy } as unknown as never;
     const mockTable = { add: jest.fn().mockResolvedValue(undefined) };
@@ -805,21 +769,8 @@ describe('RagService.indexDocument — onInsert Strategy Hook (US-003-4)', () =>
 });
 
 describe('RagService.optimizeTable (US-004)', () => {
-  const mockConfigService = {
-    get: (key: string): unknown => {
-      const config: Record<string, unknown> = {
-        'rag.lancedbPath': './lancedb',
-        'rag.similarityHigh': 0.85,
-        'rag.similarityMedium': 0.70,
-        'rag.similarityLow': 0.50,
-        'rag.ftsIndexMode': 'simple',
-      };
-      return config[key];
-    },
-  };
-
   it('calls table.optimize() when lanceAvailable is true', async () => {
-    const ragService = new RagService(mockConfigService as never);
+    const ragService = new RagService(makeRagConfig());
     const mockTable = { optimize: jest.fn().mockResolvedValue(undefined) };
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -833,7 +784,7 @@ describe('RagService.optimizeTable (US-004)', () => {
   });
 
   it('does not call table.optimize() when lanceAvailable is false', async () => {
-    const ragService = new RagService(mockConfigService as never);
+    const ragService = new RagService(makeRagConfig());
     const mockTable = { optimize: jest.fn().mockResolvedValue(undefined) };
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -848,21 +799,8 @@ describe('RagService.optimizeTable (US-004)', () => {
 });
 
 describe('RagService.deleteAllBySourceType (US-002)', () => {
-  const mockConfigService = {
-    get: (key: string): unknown => {
-      const config: Record<string, unknown> = {
-        'rag.lancedbPath': './lancedb',
-        'rag.similarityHigh': 0.85,
-        'rag.similarityMedium': 0.70,
-        'rag.similarityLow': 0.50,
-        'rag.ftsIndexMode': 'simple',
-      };
-      return config[key];
-    },
-  };
-
   it('AC1: deletes all records where source = sourceType and returns count', async () => {
-    const ragService = new RagService(mockConfigService as never);
+    const ragService = new RagService(makeRagConfig());
     const mockTable = {
       countRows: jest.fn().mockResolvedValueOnce(3).mockResolvedValueOnce(0),
       delete: jest.fn().mockResolvedValue(undefined),
@@ -878,7 +816,7 @@ describe('RagService.deleteAllBySourceType (US-002)', () => {
   });
 
   it('AC2: returns 0 when no records exist for the source type', async () => {
-    const ragService = new RagService(mockConfigService as never);
+    const ragService = new RagService(makeRagConfig());
     const mockTable = {
       countRows: jest.fn().mockResolvedValue(0),
       query: jest.fn().mockReturnValue({
@@ -904,19 +842,7 @@ describe('RagService.deleteAllBySourceType (US-002)', () => {
       dimensions: 384,
     };
 
-    const ragService = new RagService({
-      get: (key: string): unknown => {
-        const config: Record<string, unknown> = {
-          'rag.lancedbPath': './lancedb',
-          'rag.similarityHigh': 0.85,
-          'rag.similarityMedium': 0.70,
-          'rag.similarityLow': 0.50,
-          'rag.ftsIndexMode': 'simple',
-          'rag.inMemoryOnly': true,
-        };
-        return config[key];
-      },
-    } as never, mockEmbeddingService as never);
+    const ragService = new RagService(makeRagConfig({ inMemoryOnly: true }), mockEmbeddingService as never);
 
     await ragService.indexDocument('proj-1', {
       source: 'code',
@@ -941,18 +867,7 @@ describe('RagService.deleteAllBySourceType (US-002)', () => {
 });
 
 describe('RagService.importGraphify (US-002)', () => {
-  const mockConfigService = {
-    get: (key: string): unknown => {
-      const config: Record<string, unknown> = {
-        'rag.lancedbPath': './lancedb',
-        'rag.similarityHigh': 0.85,
-        'rag.similarityMedium': 0.70,
-        'rag.similarityLow': 0.50,
-        'rag.ftsIndexMode': 'simple',
-      };
-      return config[key];
-    },
-  };
+  const mockRagConfig = makeRagConfig();
 
   const mockEmbeddingService = {
     embed: jest.fn().mockResolvedValue(new Float32Array(384).fill(0)),
@@ -962,7 +877,7 @@ describe('RagService.importGraphify (US-002)', () => {
   };
 
   it('AC3: calls deleteAllBySourceType before indexing any nodes', async () => {
-    const ragService = new RagService(mockConfigService as never, mockEmbeddingService as never);
+    const ragService = new RagService(mockRagConfig, mockEmbeddingService as never);
     const callOrder: string[] = [];
     const deleteAllBySourceTypeSpy = jest.spyOn(ragService, 'deleteAllBySourceType').mockImplementation(async () => {
       callOrder.push('deleteAllBySourceType');
@@ -985,7 +900,7 @@ describe('RagService.importGraphify (US-002)', () => {
   });
 
   it('AC4: with empty links, indexes each node with content "{type} {label} in {source_file}" (omitting source_file segment when absent)', async () => {
-    const ragService = new RagService(mockConfigService as never, mockEmbeddingService as never);
+    const ragService = new RagService(mockRagConfig, mockEmbeddingService as never);
     jest.spyOn(ragService, 'deleteAllBySourceType').mockResolvedValue(0);
     const indexDocumentSpy = jest.spyOn(ragService, 'indexDocument').mockResolvedValue(undefined);
 
@@ -1016,7 +931,7 @@ describe('RagService.importGraphify (US-002)', () => {
   });
 
   it('AC5: builds content that includes "{relation} {neighbor_label}" for each link where node is the source', async () => {
-    const ragService = new RagService(mockConfigService as never, mockEmbeddingService as never);
+    const ragService = new RagService(mockRagConfig, mockEmbeddingService as never);
     jest.spyOn(ragService, 'deleteAllBySourceType').mockResolvedValue(0);
     const indexDocumentSpy = jest.spyOn(ragService, 'indexDocument').mockResolvedValue(undefined);
 
@@ -1039,7 +954,7 @@ describe('RagService.importGraphify (US-002)', () => {
   });
 
   it('AC6: calls indexDocument with source: "code", sourceId: node.id, and metadata containing label, type, source_file, and community', async () => {
-    const ragService = new RagService(mockConfigService as never, mockEmbeddingService as never);
+    const ragService = new RagService(mockRagConfig, mockEmbeddingService as never);
     jest.spyOn(ragService, 'deleteAllBySourceType').mockResolvedValue(0);
     const indexDocumentSpy = jest.spyOn(ragService, 'indexDocument').mockResolvedValue(undefined);
 
@@ -1063,7 +978,7 @@ describe('RagService.importGraphify (US-002)', () => {
   });
 
   it('AC7: returns { imported: 0, cleared: N } for empty nodes array', async () => {
-    const ragService = new RagService(mockConfigService as never, mockEmbeddingService as never);
+    const ragService = new RagService(mockRagConfig, mockEmbeddingService as never);
     jest.spyOn(ragService, 'deleteAllBySourceType').mockResolvedValue(5);
 
     const result = await ragService.importGraphify('proj-1', [], []);
@@ -1072,7 +987,7 @@ describe('RagService.importGraphify (US-002)', () => {
   });
 
   it('defaults type to "node" when absent', async () => {
-    const ragService = new RagService(mockConfigService as never, mockEmbeddingService as never);
+    const ragService = new RagService(mockRagConfig, mockEmbeddingService as never);
     jest.spyOn(ragService, 'deleteAllBySourceType').mockResolvedValue(0);
     const indexDocumentSpy = jest.spyOn(ragService, 'indexDocument').mockResolvedValue(undefined);
 
@@ -1091,7 +1006,7 @@ describe('RagService.importGraphify (US-002)', () => {
   });
 
   it('returns { imported: N, cleared: M } after successful import', async () => {
-    const ragService = new RagService(mockConfigService as never, mockEmbeddingService as never);
+    const ragService = new RagService(mockRagConfig, mockEmbeddingService as never);
     jest.spyOn(ragService, 'deleteAllBySourceType').mockResolvedValue(3);
     jest.spyOn(ragService, 'indexDocument').mockResolvedValue(undefined);
 
@@ -1125,7 +1040,7 @@ describe('RagService.search — Provenance Envelope (AC-1 through AC-6)', () => 
 
   it('AC-1: SearchKbResponseDto.provenance is non-null on success', async () => {
     const ragService = new RagService(
-      mockConfigServiceForSearch as never,
+      mockRagConfigForSearch,
       mockEmbeddingServiceForSearch as never,
     );
 
@@ -1145,7 +1060,7 @@ describe('RagService.search — Provenance Envelope (AC-1 through AC-6)', () => 
 
   it('AC-2: SearchKbResponseDto.provenance.sources lists unique source_type + source_id pairs only once', async () => {
     const ragService = new RagService(
-      mockConfigServiceForSearch as never,
+      mockRagConfigForSearch,
       mockEmbeddingServiceForSearch as never,
     );
 
@@ -1198,7 +1113,7 @@ describe('RagService.search — Provenance Envelope (AC-1 through AC-6)', () => 
 
   it('AC-3: KbResultDto.provenance.indexedAt is a valid ISO timestamp', async () => {
     const ragService = new RagService(
-      mockConfigServiceForSearch as never,
+      mockRagConfigForSearch,
       mockEmbeddingServiceForSearch as never,
     );
 
@@ -1224,7 +1139,7 @@ describe('RagService.search — Provenance Envelope (AC-1 through AC-6)', () => 
 
   it('AC-4: KbResultDto.provenance.sourceProjectId equals the request projectId', async () => {
     const ragService = new RagService(
-      mockConfigServiceForSearch as never,
+      mockRagConfigForSearch,
       mockEmbeddingServiceForSearch as never,
     );
 
@@ -1244,7 +1159,7 @@ describe('RagService.search — Provenance Envelope (AC-1 through AC-6)', () => 
 
   it('AC-5: No cross-project leakage — all results have sourceProjectId matching request', async () => {
     const ragService = new RagService(
-      mockConfigServiceForSearch as never,
+      mockRagConfigForSearch,
       mockEmbeddingServiceForSearch as never,
     );
 
@@ -1269,7 +1184,7 @@ describe('RagService.search — Provenance Envelope (AC-1 through AC-6)', () => 
 
   it('AC-6: SearchKbResponseDto.provenance.retrievedAt is within 1 second of server response', async () => {
     const ragService = new RagService(
-      mockConfigServiceForSearch as never,
+      mockRagConfigForSearch,
       mockEmbeddingServiceForSearch as never,
     );
 

--- a/apps/api/src/rag/rag.service.ts
+++ b/apps/api/src/rag/rag.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger, OnModuleDestroy, OnModuleInit, Optional, Inject, forwardRef } from '@nestjs/common';
 import { mkdirSync } from 'node:fs';
-import { ConfigService } from '@nestjs/config';
+import { RAG_CFG, IRagConfig } from '../config/rag.config';
 import { ValidationAppException, ForbiddenAppException } from '@nathapp/nestjs-common';
 import { ITransactionManager, TRANSACTION_MANAGER } from '@nathapp/nestjs-data';
 import { PrismaRagRepository } from './prisma-rag.repository';
@@ -154,7 +154,7 @@ export class RagService implements OnModuleInit, OnModuleDestroy {
   private readonly firstAccessedProjectIds = new Set<string>();
 
   constructor(
-    private readonly configService: ConfigService,
+    @Inject(RAG_CFG) ragConfig: IRagConfig,
     @Optional() private readonly embeddingService?: EmbeddingService,
     @Optional() @Inject(FTS_OPTIMIZE_STRATEGY) private readonly optimizeStrategy?: FtsOptimizeStrategy,
     @Optional() private readonly ragRepository?: PrismaRagRepository,
@@ -164,12 +164,12 @@ export class RagService implements OnModuleInit, OnModuleDestroy {
     @Optional() private readonly graphStore?: GraphStoreService,
     @Optional() @Inject(forwardRef(() => IncrementalGraphDiffService)) private readonly incrementalDiff?: IncrementalGraphDiffService,
   ) {
-    this.lancedbPath = configService.get<string>('rag.lancedbPath') ?? './lancedb';
-    this.similarityHigh = configService.get<number>('rag.similarityHigh') ?? 0.85;
-    this.similarityMedium = configService.get<number>('rag.similarityMedium') ?? 0.70;
-    this.similarityLow = configService.get<number>('rag.similarityLow') ?? 0.50;
-    this.ftsIndexMode = configService.get<string>('rag.ftsIndexMode') ?? 'simple';
-    this.inMemoryOnly = configService.get<boolean>('rag.inMemoryOnly') ?? false;
+    this.lancedbPath = ragConfig.lancedbPath;
+    this.similarityHigh = ragConfig.similarityHigh;
+    this.similarityMedium = ragConfig.similarityMedium;
+    this.similarityLow = ragConfig.similarityLow;
+    this.ftsIndexMode = ragConfig.ftsIndexMode;
+    this.inMemoryOnly = ragConfig.inMemoryOnly;
 
     if (this.inMemoryOnly) {
       this.lanceAvailable = false;

--- a/apps/api/src/rag/strategies/counter-optimize.strategy.spec.ts
+++ b/apps/api/src/rag/strategies/counter-optimize.strategy.spec.ts
@@ -1,9 +1,25 @@
-import type { ConfigService } from '@nestjs/config';
+import { IRagConfig } from '../../config/rag.config';
 import { CounterOptimizeStrategy } from './counter-optimize.strategy';
 import { FTS_OPTIMIZE_STRATEGY } from './fts-optimize-strategy.interface';
 
-function mockConfigService(values: Record<string, unknown> = {}): ConfigService {
-  return { get: jest.fn((key: string) => values[key]) } as unknown as ConfigService;
+function mockRagConfig(overrides: Partial<IRagConfig> = {}): IRagConfig {
+  return {
+    embeddingProvider: 'ollama',
+    embeddingModel: 'nomic-embed-text',
+    ollamaBaseUrl: 'http://localhost:11434',
+    openaiApiKey: '',
+    lancedbPath: './lancedb',
+    inMemoryOnly: true,
+    ftsIndexMode: 'simple',
+    similarityHigh: 0.85,
+    similarityMedium: 0.70,
+    similarityLow: 0.50,
+    ftsOptimizeStrategy: 'counter',
+    ftsOptimizeThreshold: 10,
+    ftsOptimizeIntervalMs: 300_000,
+    graphifyEnabledCacheTtlSec: 60,
+    ...overrides,
+  };
 }
 
 function mockTable() {
@@ -21,18 +37,16 @@ describe('FTS_OPTIMIZE_STRATEGY token (AC-1)', () => {
 
 describe('CounterOptimizeStrategy', () => {
   describe('AC-7: threshold config', () => {
-    it('reads threshold from rag.ftsOptimizeThreshold', async () => {
-      const strategy = new CounterOptimizeStrategy(
-        mockConfigService({ 'rag.ftsOptimizeThreshold': 2 }),
-      );
+    it('reads threshold from ragConfig.ftsOptimizeThreshold', async () => {
+      const strategy = new CounterOptimizeStrategy(mockRagConfig({ ftsOptimizeThreshold: 2 }));
       const table = mockTable();
       await strategy.onInsert('p', table);
       await strategy.onInsert('p', table); // should trigger at 2
       expect(table.optimize).toHaveBeenCalledTimes(1);
     });
 
-    it('defaults to 10 when rag.ftsOptimizeThreshold is not set', async () => {
-      const strategy = new CounterOptimizeStrategy(mockConfigService({}));
+    it('defaults to 10 when ftsOptimizeThreshold is not overridden', async () => {
+      const strategy = new CounterOptimizeStrategy(mockRagConfig());
       const table = mockTable();
       for (let i = 0; i < 9; i++) await strategy.onInsert('p', table);
       expect(table.optimize).not.toHaveBeenCalled();
@@ -41,9 +55,7 @@ describe('CounterOptimizeStrategy', () => {
 
   describe('AC-2: onInsert() triggers optimize at threshold', () => {
     it('calls table.optimize() when insert count reaches threshold', async () => {
-      const strategy = new CounterOptimizeStrategy(
-        mockConfigService({ 'rag.ftsOptimizeThreshold': 3 }),
-      );
+      const strategy = new CounterOptimizeStrategy(mockRagConfig({ ftsOptimizeThreshold: 3 }));
       const table = mockTable();
       await strategy.onInsert('p1', table);
       await strategy.onInsert('p1', table);
@@ -54,9 +66,7 @@ describe('CounterOptimizeStrategy', () => {
 
   describe('AC-3: onInsert() does not trigger below threshold', () => {
     it('does NOT call table.optimize() when count is below threshold', async () => {
-      const strategy = new CounterOptimizeStrategy(
-        mockConfigService({ 'rag.ftsOptimizeThreshold': 3 }),
-      );
+      const strategy = new CounterOptimizeStrategy(mockRagConfig({ ftsOptimizeThreshold: 3 }));
       const table = mockTable();
       await strategy.onInsert('p1', table);
       await strategy.onInsert('p1', table); // 2 < 3
@@ -66,9 +76,7 @@ describe('CounterOptimizeStrategy', () => {
 
   describe('AC-4: onInsert() resets counter after optimize', () => {
     it('resets counter to 0 after calling table.optimize()', async () => {
-      const strategy = new CounterOptimizeStrategy(
-        mockConfigService({ 'rag.ftsOptimizeThreshold': 3 }),
-      );
+      const strategy = new CounterOptimizeStrategy(mockRagConfig({ ftsOptimizeThreshold: 3 }));
       const table = mockTable();
       await strategy.onInsert('p1', table);
       await strategy.onInsert('p1', table);
@@ -82,9 +90,7 @@ describe('CounterOptimizeStrategy', () => {
 
   describe('AC-5: onInsert() handles table.optimize() rejection gracefully', () => {
     it('logs warning and does not throw when table.optimize() rejects', async () => {
-      const strategy = new CounterOptimizeStrategy(
-        mockConfigService({ 'rag.ftsOptimizeThreshold': 3 }),
-      );
+      const strategy = new CounterOptimizeStrategy(mockRagConfig({ ftsOptimizeThreshold: 3 }));
       const table = mockTable();
       table.optimize.mockRejectedValue(new Error('optimize boom'));
       await strategy.onInsert('p1', table);
@@ -95,9 +101,7 @@ describe('CounterOptimizeStrategy', () => {
 
   describe('AC-6: onFirstAccess() is fire-and-forget', () => {
     it('calls table.optimize() and returns void synchronously', () => {
-      const strategy = new CounterOptimizeStrategy(
-        mockConfigService({ 'rag.ftsOptimizeThreshold': 10 }),
-      );
+      const strategy = new CounterOptimizeStrategy(mockRagConfig({ ftsOptimizeThreshold: 10 }));
       const table = mockTable();
       const result = strategy.onFirstAccess('p1', table);
       expect(result).toBeUndefined();
@@ -107,9 +111,7 @@ describe('CounterOptimizeStrategy', () => {
 
   describe('counter isolation per projectId', () => {
     it('maintains separate counters per projectId', async () => {
-      const strategy = new CounterOptimizeStrategy(
-        mockConfigService({ 'rag.ftsOptimizeThreshold': 2 }),
-      );
+      const strategy = new CounterOptimizeStrategy(mockRagConfig({ ftsOptimizeThreshold: 2 }));
       const t1 = mockTable();
       const t2 = mockTable();
       await strategy.onInsert('p1', t1); // p1 count: 1
@@ -122,9 +124,7 @@ describe('CounterOptimizeStrategy', () => {
 
   describe('cleanup', () => {
     it('clearProject removes project counter state', async () => {
-      const strategy = new CounterOptimizeStrategy(
-        mockConfigService({ 'rag.ftsOptimizeThreshold': 2 }),
-      );
+      const strategy = new CounterOptimizeStrategy(mockRagConfig({ ftsOptimizeThreshold: 2 }));
       const table = mockTable();
       await strategy.onInsert('p1', table); // p1 count: 1
       strategy.clearProject('p1');
@@ -133,9 +133,7 @@ describe('CounterOptimizeStrategy', () => {
     });
 
     it('onDestroy clears all counters', async () => {
-      const strategy = new CounterOptimizeStrategy(
-        mockConfigService({ 'rag.ftsOptimizeThreshold': 2 }),
-      );
+      const strategy = new CounterOptimizeStrategy(mockRagConfig({ ftsOptimizeThreshold: 2 }));
       const t1 = mockTable();
       const t2 = mockTable();
       await strategy.onInsert('p1', t1);

--- a/apps/api/src/rag/strategies/counter-optimize.strategy.ts
+++ b/apps/api/src/rag/strategies/counter-optimize.strategy.ts
@@ -1,5 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { IRagConfig, RAG_CFG } from '../../config/rag.config';
 import type { FtsOptimizeStrategy } from './fts-optimize-strategy.interface';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -11,8 +11,8 @@ export class CounterOptimizeStrategy implements FtsOptimizeStrategy {
   private readonly threshold: number;
   private readonly counters = new Map<string, number>();
 
-  constructor(private readonly configService: ConfigService) {
-    this.threshold = this.configService.get<number>('rag.ftsOptimizeThreshold') ?? 10;
+  constructor(@Inject(RAG_CFG) ragConfig: IRagConfig) {
+    this.threshold = ragConfig.ftsOptimizeThreshold;
   }
 
   async onInsert(projectId: string, table: LanceTable): Promise<void> {

--- a/apps/api/src/rag/strategies/cron-optimize.strategy.spec.ts
+++ b/apps/api/src/rag/strategies/cron-optimize.strategy.spec.ts
@@ -1,8 +1,24 @@
-import type { ConfigService } from '@nestjs/config';
+import { IRagConfig } from '../../config/rag.config';
 import { CronOptimizeStrategy } from './cron-optimize.strategy';
 
-function mockConfigService(values: Record<string, unknown> = {}): ConfigService {
-  return { get: jest.fn((key: string) => values[key]) } as unknown as ConfigService;
+function mockRagConfig(overrides: Partial<IRagConfig> = {}): IRagConfig {
+  return {
+    embeddingProvider: 'ollama',
+    embeddingModel: 'nomic-embed-text',
+    ollamaBaseUrl: 'http://localhost:11434',
+    openaiApiKey: '',
+    lancedbPath: './lancedb',
+    inMemoryOnly: true,
+    ftsIndexMode: 'simple',
+    similarityHigh: 0.85,
+    similarityMedium: 0.70,
+    similarityLow: 0.50,
+    ftsOptimizeStrategy: 'cron',
+    ftsOptimizeThreshold: 10,
+    ftsOptimizeIntervalMs: 300_000,
+    graphifyEnabledCacheTtlSec: 60,
+    ...overrides,
+  };
 }
 
 function mockTable() {
@@ -17,7 +33,7 @@ function mockSchedulerRegistry() {
 
 function makeStrategy(intervalMs?: number) {
   return new CronOptimizeStrategy(
-    mockConfigService({ 'rag.ftsOptimizeIntervalMs': intervalMs }),
+    mockRagConfig(intervalMs !== undefined ? { ftsOptimizeIntervalMs: intervalMs } : {}),
     mockSchedulerRegistry() as never,
   );
 }
@@ -30,7 +46,7 @@ describe('CronOptimizeStrategy', () => {
     it('calls schedulerRegistry.addInterval("fts-optimize", interval) during construction', () => {
       const schedulerRegistry = mockSchedulerRegistry();
       new CronOptimizeStrategy(
-        mockConfigService({ 'rag.ftsOptimizeIntervalMs': 60_000 }),
+        mockRagConfig({ ftsOptimizeIntervalMs: 60_000 }),
         schedulerRegistry as never,
       );
       expect(schedulerRegistry.addInterval).toHaveBeenCalledWith('fts-optimize', expect.anything());
@@ -38,18 +54,18 @@ describe('CronOptimizeStrategy', () => {
   });
 
   describe('AC-11: reads interval from config', () => {
-    it('reads rag.ftsOptimizeIntervalMs from ConfigService', () => {
+    it('reads ftsOptimizeIntervalMs from IRagConfig', () => {
       const schedulerRegistry = mockSchedulerRegistry();
       new CronOptimizeStrategy(
-        mockConfigService({ 'rag.ftsOptimizeIntervalMs': 60_000 }),
+        mockRagConfig({ ftsOptimizeIntervalMs: 60_000 }),
         schedulerRegistry as never,
       );
       expect(schedulerRegistry.addInterval).toHaveBeenCalledWith('fts-optimize', expect.anything());
     });
 
-    it('defaults to 300000 when rag.ftsOptimizeIntervalMs is not set', () => {
+    it('uses 300000 when ftsOptimizeIntervalMs is not overridden', () => {
       const schedulerRegistry = mockSchedulerRegistry();
-      new CronOptimizeStrategy(mockConfigService({}), schedulerRegistry as never);
+      new CronOptimizeStrategy(mockRagConfig(), schedulerRegistry as never);
       expect(schedulerRegistry.addInterval).toHaveBeenCalledWith('fts-optimize', expect.anything());
     });
   });

--- a/apps/api/src/rag/strategies/cron-optimize.strategy.ts
+++ b/apps/api/src/rag/strategies/cron-optimize.strategy.ts
@@ -1,5 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { IRagConfig, RAG_CFG } from '../../config/rag.config';
 import type { FtsOptimizeStrategy } from './fts-optimize-strategy.interface';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -19,11 +19,11 @@ export class CronOptimizeStrategy implements FtsOptimizeStrategy {
   private intervalId: ReturnType<typeof setInterval> | null = null;
 
   constructor(
-    private readonly configService: ConfigService,
+    @Inject(RAG_CFG) ragConfig: IRagConfig,
     // @Inject(SchedulerRegistry) injected via NestJS DI in real usage
     private readonly schedulerRegistry: SchedulerRegistryLike,
   ) {
-    this.intervalMs = this.configService.get<number>('rag.ftsOptimizeIntervalMs') ?? 300_000;
+    this.intervalMs = ragConfig.ftsOptimizeIntervalMs;
     this.intervalId = setInterval(() => {
       void this.optimizeDirtyTables();
     }, this.intervalMs);

--- a/apps/api/src/tickets/state-machine/ticket-transitions.service.ts
+++ b/apps/api/src/tickets/state-machine/ticket-transitions.service.ts
@@ -1,5 +1,4 @@
 import { Injectable, Optional, Logger, Inject } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
 import { ITransactionManager, TRANSACTION_MANAGER } from '@nathapp/nestjs-data';
 import { NotFoundAppException, ValidationAppException } from '@nathapp/nestjs-common';
 import type {
@@ -15,6 +14,7 @@ import { VcsConnectionService } from '../../vcs/vcs-connection.service';
 import { buildBranchName } from '../../vcs/branch-name.util';
 import { createVcsProvider } from '../../vcs/factory';
 import { VcsLinkExtractorService } from '../../vcs/vcs-link-extractor.service';
+import { VCS_CFG, IVcsConfig } from '../../config/vcs.config';
 import { decryptToken } from '../../common/utils/encryption.util';
 import { TicketLinksService } from '../../ticket-links/ticket-links.service';
 import { actorForeignKeys } from '../../auth/principal/actor-foreign-keys';
@@ -47,7 +47,7 @@ export class TicketTransitionsService {
     @Optional() private readonly vcsConnectionService?: VcsConnectionService,
     @Optional() private readonly ticketLinksService?: TicketLinksService,
     @Optional() private readonly vcsLinkExtractorService?: VcsLinkExtractorService,
-    @Optional() private readonly configService?: ConfigService,
+    @Optional() @Inject(VCS_CFG) private readonly vcsConfig?: IVcsConfig,
   ) {}
 
   /**
@@ -126,11 +126,11 @@ export class TicketTransitionsService {
     project: { id: string; key: string },
     ticket: TicketDomain,
   ): Promise<void> {
-    if (!this.vcsConnectionService || !this.ticketLinksService || !this.vcsLinkExtractorService || !this.configService) return Promise.resolve();
+    if (!this.vcsConnectionService || !this.ticketLinksService || !this.vcsLinkExtractorService || !this.vcsConfig) return Promise.resolve();
 
     const vcsService = this.vcsConnectionService;
     const vcsLinkExtractor = this.vcsLinkExtractorService;
-    const encryptionKey = this.configService.get<string>('vcs.encryptionKey');
+    const encryptionKey = this.vcsConfig.encryptionKey;
     if (!encryptionKey) return Promise.resolve();
 
     const projectId = project.id;

--- a/apps/api/src/vcs/vcs-connection.service.spec.ts
+++ b/apps/api/src/vcs/vcs-connection.service.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { HttpException, HttpStatus } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
 import { NotFoundAppException, ValidationAppException } from '@nathapp/nestjs-common';
+import { VCS_CFG } from '../config/vcs.config';
 import { VcsConnectionService } from './vcs-connection.service';
 import { IVcsRepository, VCS_REPOSITORY } from './domain/vcs.repository';
 import { VcsPollingService } from './vcs-polling.service';
@@ -74,21 +74,18 @@ describe('VcsConnectionService', () => {
   let service: VcsConnectionService;
   let mockRepo: jest.Mocked<IVcsRepository>;
   let mockPolling: ReturnType<typeof createMockPollingService>;
-  let mockConfigService: { get: jest.Mock };
-
   const ENCRYPTION_KEY = 'test-key-32-chars-exactly-padded!!';
 
   beforeEach(async () => {
     mockRepo = createMockRepo();
     mockPolling = createMockPollingService();
-    mockConfigService = { get: jest.fn().mockReturnValue(null) };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         VcsConnectionService,
         { provide: VCS_REPOSITORY, useValue: mockRepo },
         { provide: VcsPollingService, useValue: mockPolling },
-        { provide: ConfigService, useValue: mockConfigService },
+        { provide: VCS_CFG, useValue: { encryptionKey: undefined, defaultPollingIntervalMs: 600000, githubApiUrl: 'https://api.github.com' } },
       ],
     }).compile();
 

--- a/apps/api/src/vcs/vcs-connection.service.ts
+++ b/apps/api/src/vcs/vcs-connection.service.ts
@@ -1,5 +1,4 @@
 import { HttpException, HttpStatus, Inject, Injectable } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
 import { NotFoundAppException, ValidationAppException } from '@nathapp/nestjs-common';
 import { VcsConnection } from '@prisma/client';
 import { randomBytes } from 'crypto';
@@ -11,12 +10,13 @@ import { TestConnectionResultDto } from './dto/test-connection-result.dto';
 import { createVcsProvider } from './factory';
 import { VcsPollingService } from './vcs-polling.service';
 import { IVcsRepository, VCS_REPOSITORY } from './domain/vcs.repository';
+import { VCS_CFG, IVcsConfig } from '../config/vcs.config';
 
 @Injectable()
 export class VcsConnectionService {
   constructor(
     @Inject(VCS_REPOSITORY) private readonly vcsRepo: IVcsRepository,
-    private readonly configService: ConfigService,
+    @Inject(VCS_CFG) private readonly vcsConfig: IVcsConfig,
     private readonly vcsPollingService: VcsPollingService,
   ) {}
 
@@ -65,7 +65,7 @@ export class VcsConnectionService {
     const syncMode = dto.syncMode ?? 'off';
     const pollingIntervalMs =
       dto.pollingIntervalMs
-      ?? this.configService.get<number>('vcs.defaultPollingIntervalMs')
+      ?? this.vcsConfig.defaultPollingIntervalMs
       ?? 600000;
 
     const connection = await this.vcsRepo.createVcsConnection({

--- a/apps/api/src/vcs/vcs-connection.service.ts
+++ b/apps/api/src/vcs/vcs-connection.service.ts
@@ -63,10 +63,7 @@ export class VcsConnectionService {
     const encryptedToken = encryptToken(dto.token, encryptionKey);
 
     const syncMode = dto.syncMode ?? 'off';
-    const pollingIntervalMs =
-      dto.pollingIntervalMs
-      ?? this.vcsConfig.defaultPollingIntervalMs
-      ?? 600000;
+    const pollingIntervalMs = dto.pollingIntervalMs ?? this.vcsConfig.defaultPollingIntervalMs;
 
     const connection = await this.vcsRepo.createVcsConnection({
       projectId,

--- a/apps/api/src/vcs/vcs-polling.service.spec.ts
+++ b/apps/api/src/vcs/vcs-polling.service.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { SchedulerRegistry } from '@nestjs/schedule';
-import { ConfigService } from '@nestjs/config';
 import { VcsPollingService } from './vcs-polling.service';
+import { VCS_CFG } from '../config/vcs.config';
 import { IVcsRepository, VCS_REPOSITORY } from './domain/vcs.repository';
 import { VcsSyncService } from './vcs-sync.service';
 import { VcsPrSyncService } from './vcs-pr-sync.service';
@@ -87,8 +87,6 @@ describe('VcsPollingService', () => {
   let mockSchedulerRegistry: jest.Mocked<Pick<SchedulerRegistry, 'addInterval' | 'deleteInterval'>>;
   let mockSyncService: jest.Mocked<Pick<VcsSyncService, 'filterByAllowedAuthors' | 'syncIssue'>>;
   let mockPrSyncService: jest.Mocked<Pick<VcsPrSyncService, 'syncPrStatus'>>;
-  let mockConfigService: { get: jest.Mock };
-
   beforeEach(async () => {
     mockRepo = createMockRepo();
 
@@ -106,10 +104,6 @@ describe('VcsPollingService', () => {
       syncPrStatus: jest.fn().mockResolvedValue({ updated: 0, skipped: 0 }),
     };
 
-    mockConfigService = {
-      get: jest.fn().mockReturnValue('test-encryption-key-32-chars-padded'),
-    };
-
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         VcsPollingService,
@@ -117,7 +111,7 @@ describe('VcsPollingService', () => {
         { provide: SchedulerRegistry, useValue: mockSchedulerRegistry },
         { provide: VcsSyncService, useValue: mockSyncService },
         { provide: VcsPrSyncService, useValue: mockPrSyncService },
-        { provide: ConfigService, useValue: mockConfigService },
+        { provide: VCS_CFG, useValue: { encryptionKey: 'test-encryption-key-32-chars-padded', defaultPollingIntervalMs: 600000, githubApiUrl: 'https://api.github.com' } },
       ],
     }).compile();
 

--- a/apps/api/src/vcs/vcs-polling.service.ts
+++ b/apps/api/src/vcs/vcs-polling.service.ts
@@ -1,12 +1,12 @@
 import { Inject, Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
 import { SchedulerRegistry } from '@nestjs/schedule';
-import { ConfigService } from '@nestjs/config';
 import { VcsConnection, Project } from '@prisma/client';
 import { decryptToken } from '../common/utils/encryption.util';
 import { createVcsProvider } from './factory';
 import { VcsSyncService } from './vcs-sync.service';
 import { VcsPrSyncService } from './vcs-pr-sync.service';
 import { IVcsRepository, VCS_REPOSITORY } from './domain/vcs.repository';
+import { VCS_CFG, IVcsConfig } from '../config/vcs.config';
 
 /**
  * Polling service for syncing issues on a schedule
@@ -21,7 +21,7 @@ export class VcsPollingService implements OnModuleInit, OnModuleDestroy {
     private readonly schedulerRegistry: SchedulerRegistry,
     private readonly syncService: VcsSyncService,
     private readonly prSyncService: VcsPrSyncService,
-    private readonly configService: ConfigService,
+    @Inject(VCS_CFG) private readonly vcsConfig: IVcsConfig,
   ) {}
 
   async onModuleInit() {
@@ -104,7 +104,7 @@ export class VcsPollingService implements OnModuleInit, OnModuleDestroy {
 
     try {
       // Get encryption key from config
-      const encryptionKey = this.configService.get<string>('vcs.encryptionKey');
+      const encryptionKey = this.vcsConfig.encryptionKey;
       if (!encryptionKey) {
         throw new Error('VCS encryption key not configured');
       }

--- a/apps/api/src/vcs/vcs-pr-sync.service.ts
+++ b/apps/api/src/vcs/vcs-pr-sync.service.ts
@@ -3,7 +3,6 @@
  */
 import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
 import { NotFoundAppException, ValidationAppException } from '@nathapp/nestjs-common';
-import { ConfigService } from '@nestjs/config';
 import { Project, Ticket, VcsConnection } from '@prisma/client';
 import { decryptToken } from '../common/utils/encryption.util';
 import { createVcsProvider } from './factory';
@@ -25,7 +24,6 @@ export class VcsPrSyncService {
   constructor(
     @Inject(VCS_REPOSITORY) private readonly vcsRepo: IVcsRepository,
     @Optional() private readonly vcsLinkExtractorService?: VcsLinkExtractorService,
-    @Optional() private readonly configService?: ConfigService,
   ) {}
 
   /**

--- a/apps/api/src/vcs/vcs-webhook.service.spec.ts
+++ b/apps/api/src/vcs/vcs-webhook.service.spec.ts
@@ -3,8 +3,8 @@ import { VcsWebhookService, GitHubWebhookPayload, WebhookHandleResult } from './
 import { VcsSyncService } from './vcs-sync.service';
 import { VcsPrSyncService } from './vcs-pr-sync.service';
 import { OutboxService } from '../outbox/outbox.service';
-import { ConfigService } from '@nestjs/config';
 import { VcsLinkExtractorService } from './vcs-link-extractor.service';
+import { VCS_CFG } from '../config/vcs.config';
 import { VcsConnection, Project } from '@prisma/client';
 import type { OutboxEventDomain } from '../outbox/domain/outbox-event.domain';
 import type { OutboxEventInput } from '../outbox/outbox.service';
@@ -169,7 +169,7 @@ function buildTestingModule(
       { provide: VcsSyncService, useValue: createMockSyncService() },
       { provide: VcsPrSyncService, useValue: createMockPrSyncService() },
       { provide: OutboxService, useValue: createMockOutboxService(enqueueMock) },
-      { provide: ConfigService, useValue: { get: jest.fn() } },
+      { provide: VCS_CFG, useValue: { encryptionKey: 'test-key', defaultPollingIntervalMs: 600000, githubApiUrl: 'https://api.github.com' } },
       { provide: VcsLinkExtractorService, useValue: { extractLinksFromPr: jest.fn() } },
     ],
   }).compile();

--- a/apps/api/src/vcs/vcs-webhook.service.ts
+++ b/apps/api/src/vcs/vcs-webhook.service.ts
@@ -1,5 +1,4 @@
 import { HttpException, HttpStatus, Inject, Injectable, Logger, OnModuleDestroy, Optional } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
 import { createHmac, timingSafeEqual } from 'crypto';
 import { VcsConnection, Project } from '@prisma/client';
 import { VcsSyncService } from './vcs-sync.service';
@@ -8,6 +7,7 @@ import { VcsLinkExtractorService } from './vcs-link-extractor.service';
 import { VcsIssue } from './types';
 import { OutboxService } from '../outbox/outbox.service';
 import { IVcsRepository, TicketLinkData, VCS_REPOSITORY } from './domain/vcs.repository';
+import { VCS_CFG, IVcsConfig } from '../config/vcs.config';
 
 /**
  * GitHub webhook event payload (issues)
@@ -86,7 +86,7 @@ export class VcsWebhookService implements OnModuleDestroy {
     private readonly syncService: VcsSyncService,
     private readonly prSyncService: VcsPrSyncService,
     @Optional() private readonly vcsLinkExtractorService?: VcsLinkExtractorService,
-    @Optional() private readonly configService?: ConfigService,
+    @Optional() @Inject(VCS_CFG) private readonly vcsConfig?: IVcsConfig,
     @Optional() private readonly outboxService?: OutboxService,
   ) {
     this.cleanupInterval = setInterval(() => {
@@ -494,8 +494,8 @@ export class VcsWebhookService implements OnModuleDestroy {
 
     // Call extractLinksFromPr to capture new commits
     // The head.ref contains the branch name that was pushed
-    if (this.vcsLinkExtractorService && this.configService) {
-      const encryptionKey = this.configService.get<string>('vcs.encryptionKey');
+    if (this.vcsLinkExtractorService) {
+      const encryptionKey = this.vcsConfig?.encryptionKey;
       if (encryptionKey) {
         try {
           await this.vcsLinkExtractorService.extractLinksFromPr(

--- a/apps/api/src/vcs/vcs-webhook.service.ts
+++ b/apps/api/src/vcs/vcs-webhook.service.ts
@@ -85,8 +85,8 @@ export class VcsWebhookService implements OnModuleDestroy {
     @Inject(VCS_REPOSITORY) private readonly vcsRepo: IVcsRepository,
     private readonly syncService: VcsSyncService,
     private readonly prSyncService: VcsPrSyncService,
+    @Inject(VCS_CFG) private readonly vcsConfig: IVcsConfig,
     @Optional() private readonly vcsLinkExtractorService?: VcsLinkExtractorService,
-    @Optional() @Inject(VCS_CFG) private readonly vcsConfig?: IVcsConfig,
     @Optional() private readonly outboxService?: OutboxService,
   ) {
     this.cleanupInterval = setInterval(() => {
@@ -495,7 +495,7 @@ export class VcsWebhookService implements OnModuleDestroy {
     // Call extractLinksFromPr to capture new commits
     // The head.ref contains the branch name that was pushed
     if (this.vcsLinkExtractorService) {
-      const encryptionKey = this.vcsConfig?.encryptionKey;
+      const encryptionKey = this.vcsConfig.encryptionKey;
       if (encryptionKey) {
         try {
           await this.vcsLinkExtractorService.extractLinksFromPr(

--- a/apps/api/src/vcs/vcs.controller.spec.ts
+++ b/apps/api/src/vcs/vcs.controller.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { HttpException, HttpStatus } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
 import { ValidationAppException } from '@nathapp/nestjs-common';
+import { VCS_CFG } from '../config/vcs.config';
 import { VcsController } from './vcs.controller';
 import { VcsConnectionService } from './vcs-connection.service';
 import { VcsSyncService } from './vcs-sync.service';
@@ -88,7 +88,7 @@ describe('VcsController', () => {
   let mockVcsService: jest.Mocked<Pick<VcsConnectionService, 'create' | 'findByProject' | 'update' | 'delete' | 'testConnection' | 'getFullByProject'>>;
   let mockSyncService: jest.Mocked<Pick<VcsSyncService, 'syncIssue' | 'fullSync'>>;
   let mockPrSyncService: jest.Mocked<Pick<VcsPrSyncService, 'syncPrStatus'>>;
-  let mockConfigService: { get: jest.Mock };
+  let mockVcsConfig: { encryptionKey: string | null };
 
   const encryptionKey = 'test-key-32-chars-exactly-padded!!';
 
@@ -115,8 +115,8 @@ describe('VcsController', () => {
       syncPrStatus: jest.fn().mockResolvedValue({ updated: 3, skipped: 0 }),
     };
 
-    mockConfigService = {
-      get: jest.fn().mockReturnValue(encryptionKey),
+    mockVcsConfig = {
+      encryptionKey,
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -126,7 +126,7 @@ describe('VcsController', () => {
         { provide: VcsSyncService, useValue: mockSyncService },
         { provide: VcsPrSyncService, useValue: mockPrSyncService },
         { provide: ProjectsService, useValue: mockProjectsService },
-        { provide: ConfigService, useValue: mockConfigService },
+        { provide: VCS_CFG, useValue: mockVcsConfig },
       ],
     }).compile();
 
@@ -155,7 +155,7 @@ describe('VcsController', () => {
     });
 
     it('should throw ValidationAppException when encryption key is not configured', async () => {
-      mockConfigService.get.mockReturnValue(null);
+      mockVcsConfig.encryptionKey = null;
 
       await expect(
         controller.createConnection('test-project', {} as CreateVcsConnectionDto),
@@ -183,7 +183,7 @@ describe('VcsController', () => {
     });
 
     it('should throw ValidationAppException when encryption key is not configured', async () => {
-      mockConfigService.get.mockReturnValue(null);
+      mockVcsConfig.encryptionKey = null;
 
       await expect(
         controller.updateConnection('test-project', {} as UpdateVcsConnectionDto),
@@ -212,7 +212,7 @@ describe('VcsController', () => {
     });
 
     it('should throw ValidationAppException when encryption key is not configured', async () => {
-      mockConfigService.get.mockReturnValue(null);
+      mockVcsConfig.encryptionKey = null;
 
       await expect(controller.testConnection('test-project')).rejects.toThrow(ValidationAppException);
     });
@@ -275,7 +275,7 @@ describe('VcsController', () => {
     });
 
     it('should throw ValidationAppException when encryption key is not configured', async () => {
-      mockConfigService.get.mockReturnValue(null);
+      mockVcsConfig.encryptionKey = null;
 
       await expect(controller.syncIssue('test-project', '5')).rejects.toThrow(ValidationAppException);
     });
@@ -300,7 +300,7 @@ describe('VcsController', () => {
     });
 
     it('should throw ValidationAppException when encryption key is not configured', async () => {
-      mockConfigService.get.mockReturnValue(null);
+      mockVcsConfig.encryptionKey = null;
 
       await expect(controller.syncAll('test-project')).rejects.toThrow(ValidationAppException);
     });
@@ -317,7 +317,7 @@ describe('VcsController', () => {
     });
 
     it('should throw ValidationAppException when encryption key is not configured', async () => {
-      mockConfigService.get.mockReturnValue(null);
+      mockVcsConfig.encryptionKey = null;
 
       await expect(controller.syncPr('test-project')).rejects.toThrow(ValidationAppException);
     });

--- a/apps/api/src/vcs/vcs.controller.ts
+++ b/apps/api/src/vcs/vcs.controller.ts
@@ -9,6 +9,7 @@ import {
   HttpCode,
   HttpStatus,
   HttpException,
+  Inject,
 } from '@nestjs/common';
 import {
   ApiTags,
@@ -17,8 +18,8 @@ import {
   ApiResponse,
 } from '@nestjs/swagger';
 import { Principal } from '@nathapp/nestjs-auth';
-import { ConfigService } from '@nestjs/config';
 import { ValidationAppException } from '@nathapp/nestjs-common';
+import { VCS_CFG, IVcsConfig } from '../config/vcs.config';
 import { Project } from '@prisma/client';
 import { VcsConnectionService } from './vcs-connection.service';
 import { VcsSyncService } from './vcs-sync.service';
@@ -41,7 +42,7 @@ export class VcsController {
     private readonly syncService: VcsSyncService,
     private readonly prSyncService: VcsPrSyncService,
     private readonly projectsService: ProjectsService,
-    private readonly configService: ConfigService,
+    @Inject(VCS_CFG) private readonly vcsConfig: IVcsConfig,
   ) {}
 
   private throwEncryptionKeyNotConfigured(): never {
@@ -64,7 +65,7 @@ export class VcsController {
     const project = await this.projectsService.findBySlug(slug);
 
     // Get encryption key from config
-    const encryptionKey = this.configService.get<string>('vcs.encryptionKey');
+    const encryptionKey = this.vcsConfig.encryptionKey;
     if (!encryptionKey) {
       this.throwEncryptionKeyNotConfigured();
     }
@@ -103,7 +104,7 @@ export class VcsController {
     const project = await this.projectsService.findBySlug(slug);
 
     // Get encryption key from config
-    const encryptionKey = this.configService.get<string>('vcs.encryptionKey');
+    const encryptionKey = this.vcsConfig.encryptionKey;
     if (!encryptionKey) {
       this.throwEncryptionKeyNotConfigured();
     }
@@ -142,7 +143,7 @@ export class VcsController {
     const project = await this.projectsService.findBySlug(slug);
 
     // Get encryption key from config
-    const encryptionKey = this.configService.get<string>('vcs.encryptionKey');
+    const encryptionKey = this.vcsConfig.encryptionKey;
     if (!encryptionKey) {
       this.throwEncryptionKeyNotConfigured();
     }
@@ -168,7 +169,7 @@ export class VcsController {
     const project = await this.projectsService.findBySlug(slug);
 
     // Get encryption key from config
-    const encryptionKey = this.configService.get<string>('vcs.encryptionKey');
+    const encryptionKey = this.vcsConfig.encryptionKey;
     if (!encryptionKey) {
       this.throwEncryptionKeyNotConfigured();
     }
@@ -229,7 +230,7 @@ export class VcsController {
     const project = await this.projectsService.findBySlug(slug);
 
     // Get encryption key from config
-    const encryptionKey = this.configService.get<string>('vcs.encryptionKey');
+    const encryptionKey = this.vcsConfig.encryptionKey;
     if (!encryptionKey) {
       this.throwEncryptionKeyNotConfigured();
     }
@@ -267,7 +268,7 @@ export class VcsController {
     const project = await this.projectsService.findBySlug(slug);
 
     // Get encryption key from config
-    const encryptionKey = this.configService.get<string>('vcs.encryptionKey');
+    const encryptionKey = this.vcsConfig.encryptionKey;
     if (!encryptionKey) {
       this.throwEncryptionKeyNotConfigured();
     }

--- a/apps/api/src/vcs/vcs.module.ts
+++ b/apps/api/src/vcs/vcs.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { ScheduleModule } from '@nestjs/schedule';
+import { ConfigModule } from '@nestjs/config';
 import { VcsController } from './vcs.controller';
 import { VcsWebhookController } from './vcs-webhook.controller';
 import { VcsConnectionService } from './vcs-connection.service';
@@ -15,7 +16,7 @@ import { VCS_REPOSITORY } from './domain/vcs.repository';
 import { OutboxModule } from '../outbox/outbox.module';
 
 @Module({
-  imports: [ScheduleModule.forRoot(), RagModule, OutboxModule, ProjectsModule],
+  imports: [ScheduleModule.forRoot(), ConfigModule, RagModule, OutboxModule, ProjectsModule],
   controllers: [VcsController, VcsWebhookController],
   providers: [
     PrismaVcsRepository,

--- a/apps/api/src/vcs/vcs.module.ts
+++ b/apps/api/src/vcs/vcs.module.ts
@@ -1,6 +1,5 @@
 import { Module } from '@nestjs/common';
 import { ScheduleModule } from '@nestjs/schedule';
-import { ConfigModule } from '@nestjs/config';
 import { VcsController } from './vcs.controller';
 import { VcsWebhookController } from './vcs-webhook.controller';
 import { VcsConnectionService } from './vcs-connection.service';
@@ -16,7 +15,7 @@ import { VCS_REPOSITORY } from './domain/vcs.repository';
 import { OutboxModule } from '../outbox/outbox.module';
 
 @Module({
-  imports: [ScheduleModule.forRoot(), ConfigModule, RagModule, OutboxModule, ProjectsModule],
+  imports: [ScheduleModule.forRoot(), RagModule, OutboxModule, ProjectsModule],
   controllers: [VcsController, VcsWebhookController],
   providers: [
     PrismaVcsRepository,

--- a/apps/api/test/integration/vcs/vcs-connection.service.spec.ts
+++ b/apps/api/test/integration/vcs/vcs-connection.service.spec.ts
@@ -18,6 +18,7 @@ import { VcsPollingService } from '../../../src/vcs/vcs-polling.service';
 import { PrismaVcsRepository } from '../../../src/vcs/prisma-vcs.repository';
 import { VCS_REPOSITORY } from '../../../src/vcs/domain/vcs.repository';
 import { TRANSACTION_MANAGER } from '@nathapp/nestjs-data';
+import { VCS_CFG, IVcsConfig } from '../../../src/config/vcs.config';
 import { CreateVcsConnectionDto, VcsProviderType, VcsSyncModeType } from '../../../src/vcs/dto/create-vcs-connection.dto';
 import { UpdateVcsConnectionDto } from '../../../src/vcs/dto/update-vcs-connection.dto';
 import { VcsConnectionResponseDto } from '../../../src/vcs/dto/vcs-connection-response.dto';
@@ -33,6 +34,12 @@ describe('VcsConnectionService', () => {
   const encryptionKey = crypto.randomBytes(32).toString('hex');
   const projectId = 'project-123';
   const connectionId = 'connection-456';
+
+  const mockVcsConfig: IVcsConfig = {
+    encryptionKey,
+    defaultPollingIntervalMs: 300000,
+    githubApiUrl: 'https://api.github.com',
+  };
 
   const mockPrismaDelegate = {
     findUnique: jest.fn(),
@@ -76,6 +83,7 @@ describe('VcsConnectionService', () => {
             get: jest.fn(),
           },
         },
+        { provide: VCS_CFG, useValue: mockVcsConfig },
         {
           provide: VcsPollingService,
           useValue: {

--- a/apps/api/test/integration/vcs/vcs-controller.spec.ts
+++ b/apps/api/test/integration/vcs/vcs-controller.spec.ts
@@ -26,6 +26,7 @@ import { VcsPrSyncService } from '../../../src/vcs/vcs-pr-sync.service';
 import { VcsWebhookService } from '../../../src/vcs/vcs-webhook.service';
 import { ProjectsService } from '../../../src/projects/projects.service';
 import { ConfigService } from '@nestjs/config';
+import { VCS_CFG, IVcsConfig } from '../../../src/config/vcs.config';
 import { CreateVcsConnectionDto, VcsProviderType } from '../../../src/vcs/dto/create-vcs-connection.dto';
 import { UpdateVcsConnectionDto } from '../../../src/vcs/dto/update-vcs-connection.dto';
 import { VcsSyncModeType } from '../../../src/vcs/dto/create-vcs-connection.dto';
@@ -45,6 +46,12 @@ describe('VcsController REST Endpoints (VCS-P1-003-C)', () => {
   const projectId = mockProject.id;
   const projectSlug = mockProject.slug;
   const encryptionKey = 'test-encryption-key-32-chars-long';
+
+  const mockVcsConfig: IVcsConfig = {
+    encryptionKey,
+    defaultPollingIntervalMs: 300000,
+    githubApiUrl: 'https://api.github.com',
+  };
 
   const mockVcsConnection: VcsConnectionResponseDto = {
     id: 'vcs-conn-123',
@@ -93,6 +100,7 @@ describe('VcsController REST Endpoints (VCS-P1-003-C)', () => {
         { provide: VcsWebhookService, useValue: {} },
         { provide: ProjectsService, useValue: mockProjectsServiceInstance },
         { provide: ConfigService, useValue: mockConfigServiceInstance },
+        { provide: VCS_CFG, useValue: mockVcsConfig },
       ],
     }).compile();
 
@@ -443,7 +451,7 @@ describe('VcsController REST Endpoints (VCS-P1-003-C)', () => {
       expect(vcsService.create).toHaveBeenCalledWith(projectId, expect.any(String), createDto);
     });
 
-    it('retrieves encryption key from config for operations that need it', async () => {
+    it('retrieves encryption key from VCS config for operations that need it', async () => {
       vcsService.create.mockResolvedValue(mockVcsConnection);
 
       const createDto: CreateVcsConnectionDto = {
@@ -455,8 +463,8 @@ describe('VcsController REST Endpoints (VCS-P1-003-C)', () => {
 
       await controller.createConnection(projectSlug, createDto);
 
-      // Verify encryption key was retrieved from config for create operation
-      expect(configService.get).toHaveBeenCalledWith('vcs.encryptionKey');
+      // Verify encryption key was passed to service from VCS_CFG token
+      expect(vcsService.create).toHaveBeenCalledWith(projectId, encryptionKey, createDto);
     });
 
     it('passes correct DTO to service on create', async () => {

--- a/apps/api/test/integration/vcs/vcs-manual-sync.spec.ts
+++ b/apps/api/test/integration/vcs/vcs-manual-sync.spec.ts
@@ -23,6 +23,7 @@ import { VcsWebhookService } from '../../../src/vcs/vcs-webhook.service';
 import { VcsPrSyncService } from '../../../src/vcs/vcs-pr-sync.service';
 import { ProjectsService } from '../../../src/projects/projects.service';
 import { ConfigService } from '@nestjs/config';
+import { VCS_CFG, IVcsConfig } from '../../../src/config/vcs.config';
 import { HttpException, HttpStatus } from '@nestjs/common';
 import { NotFoundAppException, ValidationAppException } from '@nathapp/nestjs-common';
 import { VcsIssue } from '../../../src/vcs/types';
@@ -85,6 +86,12 @@ describe('VcsController Manual Sync Endpoints (VCS-P1-004-D)', () => {
 
   const encryptionKey = 'test-encryption-key-32-chars-long';
 
+  const mockVcsConfig: IVcsConfig = {
+    encryptionKey,
+    defaultPollingIntervalMs: 300000,
+    githubApiUrl: 'https://api.github.com',
+  };
+
   const mockVcsIssue: VcsIssue = {
     number: 42,
     title: 'Fix authentication bug',
@@ -136,6 +143,7 @@ describe('VcsController Manual Sync Endpoints (VCS-P1-004-D)', () => {
         { provide: VcsWebhookService, useValue: {} },
         { provide: ProjectsService, useValue: mockProjectsServiceInstance },
         { provide: ConfigService, useValue: mockConfigServiceInstance },
+        { provide: VCS_CFG, useValue: mockVcsConfig },
       ],
     }).compile();
 

--- a/apps/api/test/integration/vcs/vcs-polling-comprehensive.spec.ts
+++ b/apps/api/test/integration/vcs/vcs-polling-comprehensive.spec.ts
@@ -23,6 +23,7 @@ import { VcsSyncService } from '../../../src/vcs/vcs-sync.service';
 import { VcsPrSyncService } from '../../../src/vcs/vcs-pr-sync.service';
 import { VCS_REPOSITORY } from '../../../src/vcs/domain/vcs.repository';
 import { VcsIssue } from '../../../src/vcs/types';
+import { VCS_CFG, IVcsConfig } from '../../../src/config/vcs.config';
 
 describe('VcsPollingService - Comprehensive Behavior Tests', () => {
   let service: VcsPollingService;
@@ -149,6 +150,12 @@ describe('VcsPollingService - Comprehensive Behavior Tests', () => {
     applyMergedPrTransition: jest.fn(),
   };
 
+  const mockVcsConfig: IVcsConfig = {
+    encryptionKey: 'test-encryption-key',
+    defaultPollingIntervalMs: 300000,
+    githubApiUrl: 'https://api.github.com',
+  };
+
   // schedulePolling() creates real Node setInterval timers. The mocked
   // SchedulerRegistry never clears them (unlike the real one), so we track and
   // clear them in afterEach to stop leaked timers from firing poll() across tests.
@@ -193,6 +200,7 @@ describe('VcsPollingService - Comprehensive Behavior Tests', () => {
           provide: ConfigService,
           useValue: { get: jest.fn().mockReturnValue('test-encryption-key') },
         },
+        { provide: VCS_CFG, useValue: mockVcsConfig },
       ],
     }).compile();
 

--- a/apps/api/test/integration/vcs/vcs-polling-pr-sync.integration.spec.ts
+++ b/apps/api/test/integration/vcs/vcs-polling-pr-sync.integration.spec.ts
@@ -16,6 +16,7 @@ import { VcsPrSyncService } from '../../../src/vcs/vcs-pr-sync.service';
 import { VCS_REPOSITORY } from '../../../src/vcs/domain/vcs.repository';
 import { VcsIssue } from '../../../src/vcs/types';
 import { ConfigService } from '@nestjs/config';
+import { VCS_CFG, IVcsConfig } from '../../../src/config/vcs.config';
 
 describe('VcsPollingService PR Sync Integration (VCS-P3-002-C AC1)', () => {
   let pollingService: VcsPollingService;
@@ -84,6 +85,12 @@ describe('VcsPollingService PR Sync Integration (VCS-P3-002-C AC1)', () => {
     vcsSyncLog: { ...mockVcsSyncLogDelegate },
   } as any;
 
+  const mockVcsConfig: IVcsConfig = {
+    encryptionKey: 'test-encryption-key',
+    defaultPollingIntervalMs: 300000,
+    githubApiUrl: 'https://api.github.com',
+  };
+
   // schedulePolling() creates real Node setInterval timers. The mocked
   // SchedulerRegistry never clears them (unlike the real one), so we track and
   // clear them in afterEach to stop leaked timers from firing poll() across tests.
@@ -118,6 +125,7 @@ describe('VcsPollingService PR Sync Integration (VCS-P3-002-C AC1)', () => {
           provide: ConfigService,
           useValue: { get: jest.fn().mockReturnValue('test-encryption-key') },
         },
+        { provide: VCS_CFG, useValue: mockVcsConfig },
         {
           provide: SchedulerRegistry,
           useValue: {

--- a/apps/api/test/integration/vcs/vcs-polling.service.spec.ts
+++ b/apps/api/test/integration/vcs/vcs-polling.service.spec.ts
@@ -23,6 +23,7 @@ import { VcsSyncService, SyncIssueResult } from '../../../src/vcs/vcs-sync.servi
 import { VcsPrSyncService } from '../../../src/vcs/vcs-pr-sync.service';
 import { VCS_REPOSITORY } from '../../../src/vcs/domain/vcs.repository';
 import { VcsIssue } from '../../../src/vcs/types';
+import { VCS_CFG, IVcsConfig } from '../../../src/config/vcs.config';
 
 describe('VcsPollingService', () => {
   let service: VcsPollingService;
@@ -136,6 +137,12 @@ describe('VcsPollingService', () => {
     applyMergedPrTransition: jest.fn(),
   };
 
+  const mockVcsConfig: IVcsConfig = {
+    encryptionKey: 'test-encryption-key',
+    defaultPollingIntervalMs: 300000,
+    githubApiUrl: 'https://api.github.com',
+  };
+
   // schedulePolling() creates real Node setInterval timers. The mocked
   // SchedulerRegistry never clears them (unlike the real one), so we track and
   // clear them in afterEach to stop leaked timers from firing poll() across tests.
@@ -180,6 +187,7 @@ describe('VcsPollingService', () => {
           provide: ConfigService,
           useValue: { get: jest.fn().mockReturnValue('test-encryption-key') },
         },
+        { provide: VCS_CFG, useValue: mockVcsConfig },
       ],
     }).compile();
 

--- a/docs/superpowers/plans/2026-06-20-config-pattern-refactor.md
+++ b/docs/superpowers/plans/2026-06-20-config-pattern-refactor.md
@@ -1,0 +1,1266 @@
+# Config Pattern Refactor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring all five config files into the nathapp pattern (DI token constant + typed interface + `validateUtil` schema class) and replace every `ConfigService.get<T>()` call in services/controllers with `@Inject(CFG_TOKEN) private config: IConfig` direct injection.
+
+**Architecture:** Each config file exports a string DI token constant (`APP_CFG`, `AUTH_CFG`, etc.), a typed interface (`IAppConfig`, etc.), and a `class-validator` schema class passed to `validateUtil`. Services inject the typed config object directly instead of using `ConfigService`. `main.ts` uses `app.get<IAppConfig>(APP_CFG)` for bootstrap values. The existing Joi `validate` in `env.validation.ts` is left in place as a complementary startup guard.
+
+**Tech Stack:** `@nestjs/config` `registerAs`, `validateUtil` from `@nathapp/nestjs-common`, `class-validator`, TypeScript strict.
+
+## Global Constraints
+
+- Never touch generated files under `apps/cli/src/generated/`.
+- Keep the same namespace strings (`'app'`, `'auth'`, `'database'`, `'rag'`, `'vcs'`) so ConfigModule's `load` array and the Joi `validate` keep working unchanged.
+- Keep every existing default value (`?? 'ollama'`, `?? 300_000`, etc.) — move them into the config factory, not the service.
+- Do **not** invoke `bun test` directly — use `npx jest` per project memory (bun leaks memory).
+- Commit after each task with the conventional commit format.
+- `validateUtil` uses `plainToClass` with `enableImplicitConversion: true` — string env vars are coerced to `number`/`boolean` before validation, so `@IsNumber()` and `@IsBoolean()` on schema class fields are safe and correct.
+- `auth.module.ts`'s `useFactory` for `NathappAuthModule.forRootAsync` legitimately uses `ConfigService` as a third-party integration adapter — do **not** change it. It is a justified exception and is intentionally left in place.
+- When spec files already exist (`auth.config.spec.ts`, `vcs.config.spec.ts`), **extend** them with new tests rather than replacing them.
+
+---
+
+### Task 1: Update `app.config.ts` — add token, interface, schema, `validateUtil`, and `host` field
+
+**Files:**
+- Modify: `apps/api/src/config/app.config.ts`
+- Create: `apps/api/src/config/app.config.spec.ts`
+
+**Interfaces:**
+- Produces: `APP_CFG = 'app'`, `IAppConfig { port, host, nodeEnv, globalPrefix }` — consumed by Task 6 (`main.ts`).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/api/src/config/app.config.spec.ts`:
+
+```typescript
+import { appConfig, IAppConfig } from './app.config';
+
+describe('appConfig', () => {
+  beforeEach(() => {
+    delete process.env['API_PORT'];
+    delete process.env['API_HOST'];
+    delete process.env['NODE_ENV'];
+    delete process.env['GLOBAL_PREFIX'];
+  });
+
+  it('returns typed IAppConfig with defaults', () => {
+    const cfg: IAppConfig = appConfig();
+    expect(cfg.port).toBe(3100);
+    expect(cfg.host).toBe('0.0.0.0');
+    expect(cfg.nodeEnv).toBe('development');
+    expect(cfg.globalPrefix).toBe('api');
+  });
+
+  it('reads API_HOST from env', () => {
+    process.env['API_HOST'] = '127.0.0.1';
+    const cfg: IAppConfig = appConfig();
+    expect(cfg.host).toBe('127.0.0.1');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd apps/api && npx jest src/config/app.config.spec.ts --no-coverage 2>&1
+```
+
+Expected: FAIL — `IAppConfig` not exported, `host` not on config.
+
+- [ ] **Step 3: Rewrite `app.config.ts`**
+
+```typescript
+import { validateUtil } from '@nathapp/nestjs-common';
+import { registerAs } from '@nestjs/config';
+import { IsNumber, IsOptional, IsString } from 'class-validator';
+
+export const APP_CFG = 'app';
+
+export interface IAppConfig {
+  port: number;
+  host: string;
+  nodeEnv: string;
+  globalPrefix: string;
+}
+
+export class AppConfigSchema {
+  @IsOptional()
+  @IsNumber()
+  API_PORT: number;
+
+  @IsOptional()
+  @IsString()
+  API_HOST: string;
+
+  @IsOptional()
+  @IsString()
+  NODE_ENV: string;
+
+  @IsOptional()
+  @IsString()
+  GLOBAL_PREFIX: string;
+}
+
+export const appConfig = registerAs(APP_CFG, (): IAppConfig => {
+  validateUtil(process.env, AppConfigSchema);
+  return {
+    port: parseInt(process.env['API_PORT'] ?? '3100', 10),
+    host: process.env['API_HOST'] ?? '0.0.0.0',
+    nodeEnv: process.env['NODE_ENV'] ?? 'development',
+    globalPrefix: process.env['GLOBAL_PREFIX'] ?? 'api',
+  };
+});
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd apps/api && npx jest src/config/app.config.spec.ts --no-coverage 2>&1
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: TypeScript check**
+
+```bash
+cd apps/api && npx tsc --noEmit 2>&1
+```
+
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/config/app.config.ts apps/api/src/config/app.config.spec.ts
+git commit -m "feat: add APP_CFG token, IAppConfig interface, and validateUtil to app.config"
+```
+
+---
+
+### Task 2: Update `auth.config.ts` — add token, interface, schema, `validateUtil`
+
+**Files:**
+- Modify: `apps/api/src/config/auth.config.ts`
+- Create: `apps/api/src/config/auth.config.spec.ts`
+
+**Interfaces:**
+- Produces: `AUTH_CFG = 'auth'`, `IAuthConfig { jwtSecret, jwtExpiresIn, jwtRefreshSecret, jwtRefreshExpiresIn, apiKeySecret }` — consumed by Task 9 (`AgentsService`).
+
+- [ ] **Step 1: Extend the existing `auth.config.spec.ts`**
+
+`apps/api/src/config/auth.config.spec.ts` already exists. Add these tests to the existing `describe` block (do NOT replace the file):
+
+```typescript
+// Add inside the existing describe block:
+import { IAuthConfig } from './auth.config'; // add to existing import
+
+it('returns typed IAuthConfig', () => {
+  process.env['JWT_SECRET'] = 'test-secret';
+  process.env['JWT_REFRESH_SECRET'] = 'test-refresh-secret';
+  process.env['API_KEY_SECRET'] = 'test-api-key-secret';
+  const cfg: IAuthConfig = authConfig();
+  expect(cfg.jwtSecret).toBe('test-secret');
+  expect(cfg.apiKeySecret).toBe('test-api-key-secret');
+  delete process.env['JWT_SECRET'];
+  delete process.env['JWT_REFRESH_SECRET'];
+  delete process.env['API_KEY_SECRET'];
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd apps/api && npx jest src/config/auth.config.spec.ts --no-coverage 2>&1
+```
+
+Expected: FAIL — `IAuthConfig` not exported.
+
+- [ ] **Step 3: Rewrite `auth.config.ts`**
+
+```typescript
+import { validateUtil } from '@nathapp/nestjs-common';
+import { registerAs } from '@nestjs/config';
+import { IsOptional, IsString } from 'class-validator';
+
+export const AUTH_CFG = 'auth';
+
+export interface IAuthConfig {
+  jwtSecret: string | undefined;
+  jwtExpiresIn: string;
+  jwtRefreshSecret: string | undefined;
+  jwtRefreshExpiresIn: string;
+  apiKeySecret: string | undefined;
+}
+
+export class AuthConfigSchema {
+  @IsString()
+  JWT_SECRET: string;
+
+  @IsOptional()
+  @IsString()
+  JWT_EXPIRES_IN: string;
+
+  @IsString()
+  JWT_REFRESH_SECRET: string;
+
+  @IsOptional()
+  @IsString()
+  JWT_REFRESH_EXPIRES_IN: string;
+
+  @IsString()
+  API_KEY_SECRET: string;
+}
+
+export const authConfig = registerAs(AUTH_CFG, (): IAuthConfig => {
+  validateUtil(process.env, AuthConfigSchema);
+  return {
+    jwtSecret: process.env['JWT_SECRET'],
+    jwtExpiresIn: process.env['JWT_EXPIRES_IN'] ?? '15m',
+    jwtRefreshSecret: process.env['JWT_REFRESH_SECRET'],
+    jwtRefreshExpiresIn: process.env['JWT_REFRESH_EXPIRES_IN'] ?? '7d',
+    apiKeySecret: process.env['API_KEY_SECRET'],
+  };
+});
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd apps/api && npx jest src/config/auth.config.spec.ts --no-coverage 2>&1
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: TypeScript check**
+
+```bash
+cd apps/api && npx tsc --noEmit 2>&1
+```
+
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/config/auth.config.ts apps/api/src/config/auth.config.spec.ts
+git commit -m "feat: add AUTH_CFG token, IAuthConfig interface, and validateUtil to auth.config"
+```
+
+---
+
+### Task 3: Update `database.config.ts` — add token, interface, schema, `validateUtil`
+
+**Files:**
+- Modify: `apps/api/src/config/database.config.ts`
+- Create: `apps/api/src/config/database.config.spec.ts`
+
+**Interfaces:**
+- Produces: `DATABASE_CFG = 'database'`, `IDatabaseConfig { url, provider }`. No service currently injects database config directly; this task applies the pattern for consistency.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/api/src/config/database.config.spec.ts`:
+
+```typescript
+import { databaseConfig, IDatabaseConfig } from './database.config';
+
+describe('databaseConfig', () => {
+  beforeEach(() => {
+    process.env['DATABASE_URL'] = 'file:./test.db';
+    delete process.env['DATABASE_PROVIDER'];
+  });
+
+  afterEach(() => {
+    delete process.env['DATABASE_URL'];
+  });
+
+  it('returns typed IDatabaseConfig with defaults', () => {
+    const cfg: IDatabaseConfig = databaseConfig();
+    expect(cfg.url).toBe('file:./test.db');
+    expect(cfg.provider).toBe('sqlite');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd apps/api && npx jest src/config/database.config.spec.ts --no-coverage 2>&1
+```
+
+Expected: FAIL — `IDatabaseConfig` not exported.
+
+- [ ] **Step 3: Rewrite `database.config.ts`**
+
+```typescript
+import { validateUtil } from '@nathapp/nestjs-common';
+import { registerAs } from '@nestjs/config';
+import { IsOptional, IsString } from 'class-validator';
+
+export const DATABASE_CFG = 'database';
+
+export interface IDatabaseConfig {
+  url: string | undefined;
+  provider: string;
+}
+
+export class DatabaseConfigSchema {
+  @IsString()
+  DATABASE_URL: string;
+
+  @IsOptional()
+  @IsString()
+  DATABASE_PROVIDER: string;
+}
+
+export const databaseConfig = registerAs(DATABASE_CFG, (): IDatabaseConfig => {
+  validateUtil(process.env, DatabaseConfigSchema);
+  return {
+    url: process.env['DATABASE_URL'],
+    provider: process.env['DATABASE_PROVIDER'] ?? 'sqlite',
+  };
+});
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd apps/api && npx jest src/config/database.config.spec.ts --no-coverage 2>&1
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: TypeScript check**
+
+```bash
+cd apps/api && npx tsc --noEmit 2>&1
+```
+
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/config/database.config.ts apps/api/src/config/database.config.spec.ts
+git commit -m "feat: add DATABASE_CFG token, IDatabaseConfig interface, and validateUtil to database.config"
+```
+
+---
+
+### Task 4: Update `rag.config.ts` — add token, interface, schema, `validateUtil`, and missing `graphifyEnabledCacheTtlSec`
+
+**Files:**
+- Modify: `apps/api/src/config/rag.config.ts`
+- Create: `apps/api/src/config/rag.config.spec.ts`
+
+**Interfaces:**
+- Produces: `RAG_CFG = 'rag'`, `IRagConfig` with all RAG fields including previously-missing `graphifyEnabledCacheTtlSec: number` (default `60`) — consumed by Tasks 7 and 8.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/api/src/config/rag.config.spec.ts`:
+
+```typescript
+import { ragConfig, IRagConfig } from './rag.config';
+
+describe('ragConfig', () => {
+  beforeEach(() => {
+    Object.keys(process.env)
+      .filter((k) => ['EMBEDDING_PROVIDER', 'EMBEDDING_MODEL', 'OLLAMA_BASE_URL',
+        'OPENAI_API_KEY', 'LANCEDB_PATH', 'RAG_IN_MEMORY_ONLY', 'FTS_INDEX_MODE',
+        'SIMILARITY_HIGH', 'SIMILARITY_MEDIUM', 'SIMILARITY_LOW',
+        'FTS_OPTIMIZE_STRATEGY', 'FTS_OPTIMIZE_THRESHOLD', 'FTS_OPTIMIZE_INTERVAL_MS',
+        'GRAPHIFY_CACHE_TTL_SEC'].includes(k))
+      .forEach((k) => delete process.env[k]);
+    process.env['NODE_ENV'] = 'test';
+  });
+
+  it('returns typed IRagConfig with defaults', () => {
+    const cfg: IRagConfig = ragConfig();
+    expect(cfg.embeddingProvider).toBe('ollama');
+    expect(cfg.embeddingModel).toBe('nomic-embed-text');
+    expect(cfg.lancedbPath).toBe('./lancedb');
+    expect(cfg.inMemoryOnly).toBe(true); // NODE_ENV=test defaults to true
+    expect(cfg.similarityHigh).toBe(0.85);
+    expect(cfg.ftsOptimizeThreshold).toBe(10);
+    expect(cfg.graphifyEnabledCacheTtlSec).toBe(60);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd apps/api && npx jest src/config/rag.config.spec.ts --no-coverage 2>&1
+```
+
+Expected: FAIL — `IRagConfig` not exported, `graphifyEnabledCacheTtlSec` missing.
+
+- [ ] **Step 3: Rewrite `rag.config.ts`**
+
+```typescript
+import { validateUtil } from '@nathapp/nestjs-common';
+import { registerAs } from '@nestjs/config';
+import { IsBoolean, IsNumber, IsOptional, IsString } from 'class-validator';
+
+export const RAG_CFG = 'rag';
+
+export interface IRagConfig {
+  embeddingProvider: string;
+  embeddingModel: string;
+  ollamaBaseUrl: string;
+  openaiApiKey: string;
+  lancedbPath: string;
+  inMemoryOnly: boolean;
+  ftsIndexMode: string;
+  similarityHigh: number;
+  similarityMedium: number;
+  similarityLow: number;
+  ftsOptimizeStrategy: string;
+  ftsOptimizeThreshold: number;
+  ftsOptimizeIntervalMs: number;
+  graphifyEnabledCacheTtlSec: number;
+}
+
+export class RagConfigSchema {
+  @IsOptional()
+  @IsString()
+  EMBEDDING_PROVIDER: string;
+
+  @IsOptional()
+  @IsString()
+  EMBEDDING_MODEL: string;
+
+  @IsOptional()
+  @IsString()
+  OLLAMA_BASE_URL: string;
+
+  @IsOptional()
+  @IsString()
+  OPENAI_API_KEY: string;
+
+  @IsOptional()
+  @IsString()
+  LANCEDB_PATH: string;
+
+  @IsOptional()
+  @IsBoolean()
+  RAG_IN_MEMORY_ONLY: boolean;
+
+  @IsOptional()
+  @IsString()
+  FTS_INDEX_MODE: string;
+
+  @IsOptional()
+  @IsNumber()
+  SIMILARITY_HIGH: number;
+
+  @IsOptional()
+  @IsNumber()
+  SIMILARITY_MEDIUM: number;
+
+  @IsOptional()
+  @IsNumber()
+  SIMILARITY_LOW: number;
+
+  @IsOptional()
+  @IsString()
+  FTS_OPTIMIZE_STRATEGY: string;
+
+  @IsOptional()
+  @IsNumber()
+  FTS_OPTIMIZE_THRESHOLD: number;
+
+  @IsOptional()
+  @IsNumber()
+  FTS_OPTIMIZE_INTERVAL_MS: number;
+
+  @IsOptional()
+  @IsNumber()
+  GRAPHIFY_CACHE_TTL_SEC: number;
+}
+
+export const ragConfig = registerAs(RAG_CFG, (): IRagConfig => {
+  validateUtil(process.env, RagConfigSchema);
+  return {
+    embeddingProvider: process.env['EMBEDDING_PROVIDER'] ?? 'ollama',
+    embeddingModel: process.env['EMBEDDING_MODEL'] ?? 'nomic-embed-text',
+    ollamaBaseUrl: process.env['OLLAMA_BASE_URL'] ?? 'http://localhost:11434',
+    openaiApiKey: process.env['OPENAI_API_KEY'] ?? '',
+    lancedbPath: process.env['LANCEDB_PATH'] ?? './lancedb',
+    inMemoryOnly: process.env['RAG_IN_MEMORY_ONLY']
+      ? process.env['RAG_IN_MEMORY_ONLY'].toLowerCase() === 'true'
+      : process.env['NODE_ENV'] === 'test',
+    ftsIndexMode: process.env['FTS_INDEX_MODE'] ?? 'simple',
+    similarityHigh: parseFloat(process.env['SIMILARITY_HIGH'] ?? '0.85'),
+    similarityMedium: parseFloat(process.env['SIMILARITY_MEDIUM'] ?? '0.70'),
+    similarityLow: parseFloat(process.env['SIMILARITY_LOW'] ?? '0.50'),
+    ftsOptimizeStrategy: process.env['FTS_OPTIMIZE_STRATEGY'] ?? 'counter',
+    ftsOptimizeThreshold: parseInt(process.env['FTS_OPTIMIZE_THRESHOLD'] ?? '10', 10),
+    ftsOptimizeIntervalMs: parseInt(process.env['FTS_OPTIMIZE_INTERVAL_MS'] ?? '300000', 10),
+    graphifyEnabledCacheTtlSec: parseInt(process.env['GRAPHIFY_CACHE_TTL_SEC'] ?? '60', 10),
+  };
+});
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd apps/api && npx jest src/config/rag.config.spec.ts --no-coverage 2>&1
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: TypeScript check**
+
+```bash
+cd apps/api && npx tsc --noEmit 2>&1
+```
+
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/config/rag.config.ts apps/api/src/config/rag.config.spec.ts
+git commit -m "feat: add RAG_CFG token, IRagConfig interface, validateUtil, and graphifyEnabledCacheTtlSec to rag.config"
+```
+
+---
+
+### Task 5: Update `vcs.config.ts` — add token, interface, schema, `validateUtil`
+
+**Files:**
+- Modify: `apps/api/src/config/vcs.config.ts`
+- Create: `apps/api/src/config/vcs.config.spec.ts`
+
+**Interfaces:**
+- Produces: `VCS_CFG = 'vcs'`, `IVcsConfig { encryptionKey, defaultPollingIntervalMs, githubApiUrl }` — consumed by Task 10.
+
+- [ ] **Step 1: Extend the existing `vcs.config.spec.ts`**
+
+`apps/api/src/config/vcs.config.spec.ts` already exists with 192 lines of tests. Add an import of `IVcsConfig` to the existing imports and one new test inside the existing `describe` block to verify the typed interface export — do NOT replace the file:
+
+```typescript
+// Add to existing imports:
+import { IVcsConfig } from './vcs.config';
+
+// Add inside the existing describe block:
+it('return value satisfies IVcsConfig interface', () => {
+  const cfg: IVcsConfig = vcsConfig();
+  expect(typeof cfg.defaultPollingIntervalMs).toBe('number');
+  expect(typeof cfg.githubApiUrl).toBe('string');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd apps/api && npx jest src/config/vcs.config.spec.ts --no-coverage 2>&1
+```
+
+Expected: FAIL — `IVcsConfig` not exported yet.
+
+- [ ] **Step 3: Rewrite `vcs.config.ts`**
+
+```typescript
+import { validateUtil } from '@nathapp/nestjs-common';
+import { registerAs } from '@nestjs/config';
+import { IsNumber, IsOptional, IsString } from 'class-validator';
+
+export const VCS_CFG = 'vcs';
+
+export interface IVcsConfig {
+  encryptionKey: string | undefined;
+  defaultPollingIntervalMs: number;
+  githubApiUrl: string;
+}
+
+export class VcsConfigSchema {
+  @IsOptional()
+  @IsString()
+  VCS_ENCRYPTION_KEY: string;
+
+  @IsOptional()
+  @IsNumber()
+  VCS_DEFAULT_POLLING_INTERVAL_MS: number;
+
+  @IsOptional()
+  @IsString()
+  GITHUB_API_URL: string;
+}
+
+export const vcsConfig = registerAs(VCS_CFG, (): IVcsConfig => {
+  validateUtil(process.env, VcsConfigSchema);
+  return {
+    encryptionKey: process.env['VCS_ENCRYPTION_KEY'],
+    defaultPollingIntervalMs: parseInt(
+      process.env['VCS_DEFAULT_POLLING_INTERVAL_MS'] ?? '600000',
+      10,
+    ),
+    githubApiUrl: process.env['GITHUB_API_URL'] ?? 'https://api.github.com',
+  };
+});
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd apps/api && npx jest src/config/vcs.config.spec.ts --no-coverage 2>&1
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: TypeScript check**
+
+```bash
+cd apps/api && npx tsc --noEmit 2>&1
+```
+
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/config/vcs.config.ts apps/api/src/config/vcs.config.spec.ts
+git commit -m "feat: add VCS_CFG token, IVcsConfig interface, and validateUtil to vcs.config"
+```
+
+---
+
+### Task 6: Fix `main.ts` — eliminate raw `process.env`, use `app.get<IAppConfig>(APP_CFG)`
+
+**Files:**
+- Modify: `apps/api/src/main.ts`
+
+**Interfaces:**
+- Consumes: `APP_CFG`, `IAppConfig` from Task 1.
+
+- [ ] **Step 1: Update `main.ts`**
+
+Replace lines 38–39 and add the import. The final `main.ts`:
+
+```typescript
+import { Readable } from 'stream';
+import { AppFactory } from '@nathapp/nestjs-app';
+import { Logger } from '@nathapp/nestjs-logging';
+import { HttpAdapterHost } from '@nestjs/core';
+import { AppModule } from './app.module';
+import { CombinedAuthGuard } from './auth/guards/combined-auth.guard';
+import { APP_CFG, IAppConfig } from './config/app.config';
+
+async function bootstrap() {
+  const app = await AppFactory.createFastifyApp(AppModule, {
+    bufferLogs: true,
+  });
+
+  app.useLogger(app.get(Logger));
+
+  // Register preParsing hook to allow empty JSON bodies before server starts
+  const { httpAdapter } = app.get(HttpAdapterHost);
+  const fastify = httpAdapter.getInstance();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  fastify.addHook('preParsing', async (request: any, _reply: unknown, payload: AsyncIterable<Buffer>) => {
+    const ct = String(request.headers?.['content-type'] ?? '');
+    if (!ct.includes('application/json')) return payload;
+
+    // Collect the entire body stream
+    const chunks: Buffer[] = [];
+    for await (const chunk of payload) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    }
+
+    // Use empty JSON object if body is empty
+    const body = chunks.length > 0 ? Buffer.concat(chunks) : Buffer.from('{}');
+
+    // Update Content-Length so Fastify's parser doesn't throw size mismatch
+    request.headers['content-length'] = String(body.length);
+
+    return Readable.from([body]);
+  });
+
+  const { port, host } = app.get<IAppConfig>(APP_CFG);
+
+  // DI container is ready right after createFastifyApp() — get the guard before
+  // setting up global handlers. Global guards MUST be registered before init()
+  // because NestJS compiles route handlers (capturing guards) during init().
+  const combinedGuard = app.get(CombinedAuthGuard);
+  app.setJwtAuthGuard(combinedGuard);
+
+  app
+    .useAppGlobalPrefix()
+    .useAppGlobalPipes()
+    .useAppGlobalFilters()
+    .useAppGlobalGuards()
+    .useSwaggerUIOnDevOnly({
+      name: 'Koda API',
+      description: 'Dev ticket tracker API',
+      version: '1.0.0',
+    });
+
+  await app.start(port, host);
+}
+
+bootstrap();
+```
+
+- [ ] **Step 2: TypeScript check**
+
+```bash
+cd apps/api && npx tsc --noEmit 2>&1
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/src/main.ts
+git commit -m "fix: replace process.env in main.ts with app.get IAppConfig via APP_CFG token"
+```
+
+---
+
+### Task 7: Fix RAG services — `EmbeddingService`, `HybridRetrieverService`, `RagService`
+
+**Files:**
+- Modify: `apps/api/src/rag/embedding.service.ts`
+- Modify: `apps/api/src/rag/hybrid-retriever.service.ts`
+- Modify: `apps/api/src/rag/rag.service.ts`
+
+**Interfaces:**
+- Consumes: `RAG_CFG`, `IRagConfig` from Task 4.
+
+- [ ] **Step 1: Update `embedding.service.ts`**
+
+Replace the constructor signature and all config reads:
+
+```typescript
+import { Injectable, Inject } from '@nestjs/common';
+import { RAG_CFG, IRagConfig } from '../config/rag.config';
+import { EmbeddingProvider } from './embedding.interface';
+import { OllamaEmbeddingProvider } from './providers/ollama-embedding.provider';
+import { OpenAIEmbeddingProvider } from './providers/openai-embedding.provider';
+
+@Injectable()
+export class EmbeddingService {
+  private readonly provider: EmbeddingProvider;
+  private readonly _modelName: string;
+
+  constructor(@Inject(RAG_CFG) ragConfig: IRagConfig) {
+    const { embeddingProvider, embeddingModel, openaiApiKey, ollamaBaseUrl } = ragConfig;
+    this._modelName = embeddingModel;
+
+    if (embeddingProvider === 'openai') {
+      this.provider = new OpenAIEmbeddingProvider(openaiApiKey, embeddingModel);
+    } else {
+      this.provider = new OllamaEmbeddingProvider(ollamaBaseUrl, embeddingModel);
+    }
+  }
+  // ... rest of file unchanged
+}
+```
+
+- [ ] **Step 2: Update `hybrid-retriever.service.ts` constructor**
+
+Replace the `ConfigService` import and constructor. Change the six config reads:
+
+```typescript
+// Remove: import { ConfigService } from '@nestjs/config';
+// Add:
+import { RAG_CFG, IRagConfig } from '../config/rag.config';
+
+// In the constructor parameter list, replace:
+//   private readonly configService: ConfigService,
+// with:
+//   @Inject(RAG_CFG) ragConfig: IRagConfig,
+
+// Replace the six configService.get lines with:
+    this.lancedbPath = ragConfig.lancedbPath;
+    this.similarityHigh = ragConfig.similarityHigh;
+    this.similarityMedium = ragConfig.similarityMedium;
+    this.similarityLow = ragConfig.similarityLow;
+    this.inMemoryOnly = ragConfig.inMemoryOnly;
+    this.graphifyEnabledCacheTtlMs = ragConfig.graphifyEnabledCacheTtlSec * 1000;
+```
+
+Note: the original code stored the value in `graphifyEnabledCacheTtlMs` (milliseconds) but read from `rag.graphifyEnabledCacheTtlSec` without multiplying by 1000 — a pre-existing bug. The `* 1000` conversion is intentionally added here as a bundled bug fix.
+
+- [ ] **Step 3: Update `rag.service.ts` constructor**
+
+Replace the `ConfigService` import and constructor. Change the six config reads:
+
+```typescript
+// Remove: import { ConfigService } from '@nestjs/config';
+// Add:
+import { RAG_CFG, IRagConfig } from '../config/rag.config';
+
+// In the constructor parameter list, replace:
+//   private readonly configService: ConfigService,
+// with:
+//   @Inject(RAG_CFG) ragConfig: IRagConfig,
+
+// Replace the six configService.get lines with:
+    this.lancedbPath = ragConfig.lancedbPath;
+    this.similarityHigh = ragConfig.similarityHigh;
+    this.similarityMedium = ragConfig.similarityMedium;
+    this.similarityLow = ragConfig.similarityLow;
+    this.ftsIndexMode = ragConfig.ftsIndexMode;
+    this.inMemoryOnly = ragConfig.inMemoryOnly;
+```
+
+- [ ] **Step 4: TypeScript check**
+
+```bash
+cd apps/api && npx tsc --noEmit 2>&1
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Run unit tests**
+
+```bash
+cd apps/api && npx jest src/rag/ --testPathIgnorePatterns='integration|e2e' --no-coverage 2>&1
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/rag/embedding.service.ts \
+        apps/api/src/rag/hybrid-retriever.service.ts \
+        apps/api/src/rag/rag.service.ts
+git commit -m "fix: replace ConfigService with @Inject(RAG_CFG) IRagConfig in RAG services"
+```
+
+---
+
+### Task 8: Fix RAG strategies and module factory
+
+**Files:**
+- Modify: `apps/api/src/rag/strategies/counter-optimize.strategy.ts`
+- Modify: `apps/api/src/rag/strategies/cron-optimize.strategy.ts`
+- Modify: `apps/api/src/rag/rag.module.ts`
+
+**Interfaces:**
+- Consumes: `RAG_CFG`, `IRagConfig` from Task 4.
+
+- [ ] **Step 1: Update `counter-optimize.strategy.ts`**
+
+```typescript
+// Remove: import { ConfigService } from '@nestjs/config';
+// Add:
+import { RAG_CFG, IRagConfig } from '../../config/rag.config';
+
+// Change constructor:
+  constructor(@Inject(RAG_CFG) ragConfig: IRagConfig) {
+    this.threshold = ragConfig.ftsOptimizeThreshold;
+  }
+```
+
+Remove `private readonly configService: ConfigService` from the class body — it is no longer stored.
+
+- [ ] **Step 2: Update `cron-optimize.strategy.ts`**
+
+```typescript
+// Remove: import { ConfigService } from '@nestjs/config';
+// Add:
+import { RAG_CFG, IRagConfig } from '../../config/rag.config';
+
+// Change constructor (ConfigService is first param, SchedulerRegistryLike is second):
+  constructor(
+    @Inject(RAG_CFG) ragConfig: IRagConfig,
+    private readonly schedulerRegistry: SchedulerRegistryLike,
+  ) {
+    this.intervalMs = ragConfig.ftsOptimizeIntervalMs;
+    this.intervalId = setInterval(() => {
+      void this.optimizeDirtyTables();
+    }, this.intervalMs);
+    this.schedulerRegistry.addInterval('fts-optimize', this.intervalId);
+  }
+```
+
+Remove `private readonly configService: ConfigService` from the class body.
+
+- [ ] **Step 3: Update `rag.module.ts` useFactory**
+
+```typescript
+// Remove: import { ConfigService } from '@nestjs/config';
+// Add:
+import { RAG_CFG, IRagConfig } from '../config/rag.config';
+
+// Change the FTS_OPTIMIZE_STRATEGY provider:
+    {
+      provide: FTS_OPTIMIZE_STRATEGY,
+      useFactory: (ragConfig: IRagConfig, schedulerRegistry: SchedulerRegistry): FtsOptimizeStrategy => {
+        const strategy = ragConfig.ftsOptimizeStrategy;
+
+        switch (strategy) {
+          case 'cron':
+            return new CronOptimizeStrategy(ragConfig, schedulerRegistry);
+          case 'manual':
+            return new ManualOptimizeStrategy();
+          case 'counter':
+          default:
+            return new CounterOptimizeStrategy(ragConfig);
+        }
+      },
+      inject: [RAG_CFG, SchedulerRegistry],
+    },
+```
+
+Note: `CronOptimizeStrategy` and `CounterOptimizeStrategy` constructors now take `IRagConfig` instead of `ConfigService` (from Steps 1–2 above), so the factory passes `ragConfig` directly.
+
+- [ ] **Step 4: TypeScript check**
+
+```bash
+cd apps/api && npx tsc --noEmit 2>&1
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Run unit tests**
+
+```bash
+cd apps/api && npx jest src/rag/ --testPathIgnorePatterns='integration|e2e' --no-coverage 2>&1
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/rag/strategies/counter-optimize.strategy.ts \
+        apps/api/src/rag/strategies/cron-optimize.strategy.ts \
+        apps/api/src/rag/rag.module.ts
+git commit -m "fix: replace ConfigService with @Inject(RAG_CFG) IRagConfig in RAG strategies and module"
+```
+
+---
+
+### Task 9: Fix `AgentsService`
+
+**Files:**
+- Modify: `apps/api/src/agents/agents.service.ts`
+
+**Interfaces:**
+- Consumes: `AUTH_CFG`, `IAuthConfig` from Task 2.
+
+- [ ] **Step 1: Update `agents.service.ts`**
+
+```typescript
+// Remove: import { ConfigService } from '@nestjs/config';
+// Add:
+import { AUTH_CFG, IAuthConfig } from '../config/auth.config';
+
+// Change constructor — replace `private configService: ConfigService`:
+  constructor(
+    private readonly agentRepo: PrismaAgentRepository,
+    @Inject(AUTH_CFG) private readonly authConfig: IAuthConfig,
+    @Optional() private readonly kodaDomainWriter?: KodaDomainWriter,
+    @Optional() private readonly agentAuthProvider?: AgentAuthProvider,
+  ) {}
+
+// In generateApiKey(), replace the two config lines:
+//   const authCfg = this.configService.get<{ apiKeySecret?: string }>('auth');
+//   const apiKeySecret = authCfg?.apiKeySecret;
+// with:
+    const apiKeySecret = this.authConfig.apiKeySecret;
+```
+
+- [ ] **Step 2: TypeScript check**
+
+```bash
+cd apps/api && npx tsc --noEmit 2>&1
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Run unit tests**
+
+```bash
+cd apps/api && npx jest src/agents/ --testPathIgnorePatterns='integration|e2e' --no-coverage 2>&1
+```
+
+Expected: all pass. If any test instantiates `AgentsService` with a mock `ConfigService`, update that mock to provide `@Inject(AUTH_CFG)` with `{ apiKeySecret: 'test-secret' }` instead.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/src/agents/agents.service.ts
+git commit -m "fix: replace ConfigService with @Inject(AUTH_CFG) IAuthConfig in AgentsService"
+```
+
+---
+
+### Task 10: Fix VCS controller, services, and ticket transitions
+
+**Files:**
+- Modify: `apps/api/src/vcs/vcs.controller.ts`
+- Modify: `apps/api/src/vcs/vcs-connection.service.ts`
+- Modify: `apps/api/src/vcs/vcs-polling.service.ts`
+- Modify: `apps/api/src/vcs/vcs-webhook.service.ts`
+- Modify: `apps/api/src/vcs/vcs-pr-sync.service.ts` (dead code removal only)
+- Modify: `apps/api/src/code-intel/code-commit-outbox-handler.ts`
+- Modify: `apps/api/src/auth/guards/combined-auth.guard.ts`
+- Modify: `apps/api/src/tickets/state-machine/ticket-transitions.service.ts`
+
+**Interfaces:**
+- Consumes: `VCS_CFG`, `IVcsConfig` from Task 5; `AUTH_CFG`, `IAuthConfig` from Task 2.
+
+- [ ] **Step 1: Update `vcs.controller.ts`**
+
+```typescript
+// Remove: import { ConfigService } from '@nestjs/config';
+// Add:
+import { VCS_CFG, IVcsConfig } from '../config/vcs.config';
+
+// Change constructor — replace `private readonly configService: ConfigService`:
+  constructor(
+    private readonly vcsService: VcsConnectionService,
+    private readonly syncService: VcsSyncService,
+    private readonly prSyncService: VcsPrSyncService,
+    private readonly projectsService: ProjectsService,
+    @Inject(VCS_CFG) private readonly vcsConfig: IVcsConfig,
+  ) {}
+
+// Replace all six occurrences of:
+//   const encryptionKey = this.configService.get<string>('vcs.encryptionKey');
+// with:
+    const encryptionKey = this.vcsConfig.encryptionKey;
+```
+
+The `if (!encryptionKey) { this.throwEncryptionKeyNotConfigured(); }` guards remain unchanged.
+
+- [ ] **Step 2: Update `vcs-connection.service.ts`**
+
+```typescript
+// Remove: import { ConfigService } from '@nestjs/config';
+// Add:
+import { VCS_CFG, IVcsConfig } from '../config/vcs.config';
+
+// Change constructor — replace `private readonly configService: ConfigService`:
+  constructor(
+    @Inject(VCS_REPOSITORY) private readonly vcsRepo: IVcsRepository,
+    @Inject(VCS_CFG) private readonly vcsConfig: IVcsConfig,
+    private readonly vcsPollingService: VcsPollingService,
+  ) {}
+
+// Replace (line ~68):
+//   ?? this.configService.get<number>('vcs.defaultPollingIntervalMs')
+// with:
+//   ?? this.vcsConfig.defaultPollingIntervalMs
+```
+
+The full expression becomes:
+```typescript
+    const pollingIntervalMs =
+      dto.pollingIntervalMs
+      ?? this.vcsConfig.defaultPollingIntervalMs
+      ?? 600000;
+```
+
+- [ ] **Step 3: Update `vcs-polling.service.ts`**
+
+```typescript
+// Remove: import { ConfigService } from '@nestjs/config';
+// Add:
+import { VCS_CFG, IVcsConfig } from '../config/vcs.config';
+
+// Change constructor — replace `private readonly configService: ConfigService`:
+  constructor(
+    @Inject(VCS_REPOSITORY) private readonly vcsRepo: IVcsRepository,
+    private readonly schedulerRegistry: SchedulerRegistry,
+    private readonly syncService: VcsSyncService,
+    private readonly prSyncService: VcsPrSyncService,
+    @Inject(VCS_CFG) private readonly vcsConfig: IVcsConfig,
+  ) {}
+
+// Replace in poll() method:
+//   const encryptionKey = this.configService.get<string>('vcs.encryptionKey');
+// with:
+      const encryptionKey = this.vcsConfig.encryptionKey;
+```
+
+- [ ] **Step 4: Update `vcs-webhook.service.ts`**
+
+```typescript
+// Remove: import { ConfigService } from '@nestjs/config';
+// Add:
+import { VCS_CFG, IVcsConfig } from '../config/vcs.config';
+
+// Change constructor — find ConfigService in the constructor params and replace with:
+//   @Inject(VCS_CFG) private readonly vcsConfig: IVcsConfig,
+// (keep all other constructor params unchanged)
+
+// Replace:
+//   const encryptionKey = this.configService.get<string>('vcs.encryptionKey');
+// with:
+      const encryptionKey = this.vcsConfig.encryptionKey;
+
+// The guard that checked for configService becomes a check for vcsLinkExtractorService only
+// (vcsConfig is non-optional so it is always truthy — no need to guard on it):
+//   if (this.vcsLinkExtractorService && this.configService) {
+// becomes:
+      if (this.vcsLinkExtractorService) {
+```
+
+- [ ] **Step 5: Remove dead `ConfigService` injection from `vcs-pr-sync.service.ts`**
+
+`VcsPrSyncService` receives `encryptionKey` as a plain parameter to `syncPrStatus()` and never calls `configService.get()`. Remove the dead field:
+
+```typescript
+// Remove: import { ConfigService } from '@nestjs/config';
+// Remove from constructor params:
+//   @Optional() private readonly configService?: ConfigService,
+```
+
+The remaining constructor is:
+```typescript
+  constructor(
+    @Inject(VCS_REPOSITORY) private readonly vcsRepo: IVcsRepository,
+    @Optional() private readonly vcsLinkExtractorService?: VcsLinkExtractorService,
+  ) {}
+```
+
+- [ ] **Step 6: Update `code-commit-outbox-handler.ts` in `src/code-intel/`**
+
+```typescript
+// Remove: import { ConfigService } from '@nestjs/config';
+// Add:
+import { VCS_CFG, IVcsConfig } from '../config/vcs.config';
+
+// Change constructor — replace:
+//   @Optional() @Inject(ConfigService) private readonly configService?: ConfigService,
+// with:
+    @Optional() @Inject(VCS_CFG) private readonly vcsConfig?: IVcsConfig,
+
+// Replace:
+//   const encryptionKey = this.configService?.get<string>('vcs.encryptionKey');
+// with:
+    const encryptionKey = this.vcsConfig?.encryptionKey;
+```
+
+- [ ] **Step 7: Update `combined-auth.guard.ts` in `src/auth/guards/`**
+
+```typescript
+// Remove: import { ConfigService } from '@nestjs/config';
+// Add:
+import { AUTH_CFG, IAuthConfig } from '../config/auth.config';
+
+// Change constructor — replace:
+//   private readonly config: ConfigService,
+// with:
+    @Inject(AUTH_CFG) private readonly authConfig: IAuthConfig,
+
+// Replace in tryApiKey():
+//   const authCfg = this.config.get<{ apiKeySecret?: string }>('auth');
+//   const secret = authCfg?.apiKeySecret;
+// with:
+    const secret = this.authConfig.apiKeySecret;
+    if (!secret) {
+      this.combinedLogger.error('auth.apiKeySecret not configured');
+      return false;
+    }
+```
+
+Remove the now-unused `if (!secret)` check that immediately followed the old two-liner (it is now inlined above).
+
+- [ ] **Step 8: Update `ticket-transitions.service.ts`**
+
+```typescript
+// Remove: import { ConfigService } from '@nestjs/config';
+// Add:
+import { VCS_CFG, IVcsConfig } from '../../config/vcs.config';
+
+// In constructor params, replace:
+//   @Optional() private readonly configService?: ConfigService,
+// with:
+    @Optional() @Inject(VCS_CFG) private readonly vcsConfig?: IVcsConfig,
+
+// In createPrForTicket(), replace:
+//   if (!this.vcsConnectionService || !this.ticketLinksService || !this.vcsLinkExtractorService || !this.configService) return Promise.resolve();
+//   ...
+//   const encryptionKey = this.configService.get<string>('vcs.encryptionKey');
+// with:
+    if (!this.vcsConnectionService || !this.ticketLinksService || !this.vcsLinkExtractorService || !this.vcsConfig) return Promise.resolve();
+    ...
+    const encryptionKey = this.vcsConfig.encryptionKey;
+```
+
+- [ ] **Step 9: TypeScript check**
+
+```bash
+cd apps/api && npx tsc --noEmit 2>&1
+```
+
+Expected: no errors.
+
+- [ ] **Step 10: Run unit tests**
+
+```bash
+cd apps/api && npx jest src/vcs/ src/tickets/ src/auth/ src/code-intel/ --testPathIgnorePatterns='integration|e2e' --no-coverage 2>&1
+```
+
+Expected: all pass. For any test that previously mocked `ConfigService`, replace it with the appropriate typed config token:
+- `{ provide: VCS_CFG, useValue: { encryptionKey: 'test-key', defaultPollingIntervalMs: 600000, githubApiUrl: 'https://api.github.com' } }`
+- `{ provide: AUTH_CFG, useValue: { apiKeySecret: 'test-secret', jwtSecret: undefined, jwtExpiresIn: '15m', jwtRefreshSecret: undefined, jwtRefreshExpiresIn: '7d' } }`
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add apps/api/src/vcs/vcs.controller.ts \
+        apps/api/src/vcs/vcs-connection.service.ts \
+        apps/api/src/vcs/vcs-polling.service.ts \
+        apps/api/src/vcs/vcs-webhook.service.ts \
+        apps/api/src/vcs/vcs-pr-sync.service.ts \
+        apps/api/src/code-intel/code-commit-outbox-handler.ts \
+        apps/api/src/auth/guards/combined-auth.guard.ts \
+        apps/api/src/tickets/state-machine/ticket-transitions.service.ts
+git commit -m "fix: replace ConfigService with typed config token injection in VCS, auth guard, code-intel, and ticket transitions"
+```
+
+---
+
+### Task 11: Final verification
+
+- [ ] **Step 1: Grep for remaining `ConfigService.get` violations**
+
+```bash
+grep -rn 'configService\.get\|\.config\.get\b' apps/api/src/ 2>&1
+```
+
+Expected: no output. The only legitimate remaining `ConfigService` usage is inside `auth.module.ts`'s `useFactory` for `NathappAuthModule.forRootAsync` — this is a justified third-party integration exception and does NOT call `.get()` via a stored field; it is injected as a factory parameter. Verify with:
+
+```bash
+grep -n 'ConfigService' apps/api/src/auth/auth.module.ts 2>&1
+```
+
+That file is the only acceptable remaining consumer of `ConfigService`.
+
+- [ ] **Step 2: Grep for raw `process.env` outside config files**
+
+```bash
+grep -rn 'process\.env' apps/api/src/ | grep -v 'apps/api/src/config/' 2>&1
+```
+
+Expected: no output.
+
+- [ ] **Step 3: Full unit test run**
+
+```bash
+cd apps/api && npx jest --testPathIgnorePatterns='integration|e2e' --no-coverage 2>&1
+```
+
+Expected: all pass.
+
+- [ ] **Step 4: Final TypeScript check**
+
+```bash
+cd apps/api && npx tsc --noEmit 2>&1
+```
+
+Expected: no errors.


### PR DESCRIPTION
## Summary

- Introduces a `ConfigBridgeModule` (`@Global()`) that bridges NestJS `ConfigModule` namespace objects to typed DI tokens (`APP_CFG`, `AUTH_CFG`, `DATABASE_CFG`, `RAG_CFG`, `VCS_CFG`), each backed by a typed interface and `validateUtil`-validated schema class
- Replaces all `configService.get('ns.key', { infer: true })` calls across services, controllers, strategies, and guards with `@Inject(CFG_TOKEN) private readonly config: IConfig` injection
- Adds `GlobalStubsModule` exports for all new config tokens so module-wiring unit tests compile without a real ConfigModule bootstrap

## What changed

- `src/config/app.config.ts` — `APP_CFG` token, `IAppConfig`, `AppConfigSchema`, `validateUtil`
- `src/config/auth.config.ts` — `AUTH_CFG` token, `IAuthConfig`, `AuthConfigSchema`, `validateUtil`; non-null asserts on factory fields to match schema guarantees
- `src/config/database.config.ts` — `DATABASE_CFG` token, `IDatabaseConfig`, `DatabaseConfigSchema`, `validateUtil`
- `src/config/rag.config.ts` — `RAG_CFG` token, `IRagConfig`, `RagConfigSchema`, `validateUtil`; added `graphifyEnabledCacheTtlSec`
- `src/config/vcs.config.ts` — `VCS_CFG` token, `IVcsConfig`, `VcsConfigSchema`, `validateUtil`
- `src/config/config-bridge.module.ts` — new `@Global()` bridge module; factories throw on `undefined` to catch missing `load:` entries at startup
- `src/app.module.ts` — imports `ConfigBridgeModule`
- `src/main.ts` — reads port/host from `IAppConfig` via DI instead of `process.env`
- `src/rag/` (3 services + 2 strategies + module) — `@Inject(RAG_CFG)` injection; `graphifyEnabledCacheTtlSec` unit fixed (`* 1000` removed, was double-converting)
- `src/agents/agents.service.ts` — `@Inject(AUTH_CFG)` injection
- `src/vcs/` (controller, 4 services) — `@Inject(VCS_CFG)` injection
- `src/auth/guards/combined-auth.guard.ts` — `@Inject(AUTH_CFG)` injection
- `src/common/test-helpers/global-stubs.module.ts` — typed mock configs + token exports for `AUTH_CFG`, `RAG_CFG`, `VCS_CFG`

## Test plan

- [ ] `npx tsc --noEmit` passes (0 errors)
- [ ] `npx jest --no-coverage --testPathIgnorePatterns=integration` — 136 suites, 1960 tests, all pass
- [ ] Confirm `ConfigBridgeModule` factory errors are legible if a config namespace is missing from `load:`
- [ ] Smoke-test API startup locally with `.env` populated